### PR TITLE
docs: add English and Japanese README versions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,114 @@
+# /tms:review-pr — Agent Review Pull Request Github
+
+[Tiếng Việt](./README.md) · **English** · [日本語](./README.ja.md)
+
+A plugin that teaches the Agent to review GitHub Pull Requests **consistently** — the more you use it, the better it understands your project.
+
+The first time, it reads your existing conventions (README, CLAUDE.md, AGENTS.md, docs, wiki…). After that it always applies that repo's specific rules; type an extra rule in chat and it remembers it right away into the memory for that repo — close to the real conventions, light on generic rules.
+
+What if a suggestion only lives on a PR comment? It asks you before remembering (to avoid injecting fake rules through a PR).
+
+Project conventions don't stand still — on each `/tms:review-pr`, if it's due, the plugin re-reads the convention docs so memory doesn't go stale. Schedule details: [Convention refresh cycle](#convention-refresh-cycle).
+
+## Prerequisites
+
+- [Claude Code](https://claude.ai/code) installed
+- [`gh`](https://cli.github.com/) logged in (`gh auth login`) — the plugin posts reviews through this account
+
+## Install
+
+Inside a Claude Code session:
+
+```
+/plugin marketplace add TOMOSIA-VIETNAM/tms-review-pr
+/plugin install tms@review-pr
+```
+
+## Update to the latest
+
+`plugin.json` declares no `version` (the project is under active development) — every new commit on `main` becomes a build of its own. Once installed, pull the latest:
+
+```
+/plugin marketplace update review-pr
+/plugin update tms@review-pr
+```
+
+Then `/reload-plugins` (or open a new Claude Code session) to reload.
+
+## How to use
+
+The slash command **only runs when you type it** — Claude never calls `/tms:review-pr` on its own.
+
+```
+/tms:review-pr https://github.com/<owner>/<repo>/pull/<number>
+```
+
+URLs ending in `/files`, `/changes`, with query strings… all work — they just need to contain a valid PR link.
+
+Add instructions right after the URL for **that run only** (does not change saved config), e.g.:
+
+```
+/tms:review-pr https://github.com/org/repo/pull/123 focus on security
+```
+
+**Works in parallel, no fear of clobbering branches.** On each review, the PR code is checked out into its own [git worktree](https://git-scm.com/docs/git-worktree) — it does not change the branch/working tree of the repo you're coding in. You can open multiple `/tms:review-pr` sessions (several PRs at once) while still committing/editing normally on your current branch.
+
+## First time for a repo that's never been set up
+
+The plugin asks **once** (4 questions):
+
+1. Review **language** (vi / en / ja)
+2. **Post the review now or keep it as a draft?** (`auto_submit_review`) — `true`: everyone sees it immediately; `false` (default): a draft on GitHub you Submit yourself
+3. **Auto-close a thread when an old finding is fixed?** (`auto_resolve_fixed_findings`) — default `false`
+4. **How often to re-scan project conventions?** — see [Convention refresh cycle](#convention-refresh-cycle) below (default every **1 month**)
+
+After that it reads your existing convention docs and remembers them for later runs.
+
+Remembered data lives inside the repo you're reviewing, at `notebooks/review/<repo-name>/` (its own local git, not pushed). Keep this directory in your project's `.gitignore` — the plugin adds it if missing.
+
+## How it works (short)
+
+```
+/tms:review-pr <PR_URL>
+        │
+        ▼
+Check out the PR code into its own worktree (won't touch the branch you're working on)
+        │
+        ▼
+Review the changes, following:
+  • general technical rules
+  • the conventions / memory of this specific repo
+        │
+        ▼
+Post 1 review: overview + line-by-line comments (when needed)
+  • severity as emoji: 🔴 MUST FIX / 🟠 SHOULD FIX / 🔵 SUGGESTION / 📝 NOTE
+  • clean PR → **LGTM 🌟**, no nitpicking
+```
+
+Supports many stacks: Rails, Vue, React, Python, Node.js, Lambda, PHP, Laravel, WordPress, Shell, Makefile (and extends itself when it meets a new stack).
+
+**Review + comment only.** No closing/merging PRs, no branch switching, no editing code for you.
+
+## Convention refresh cycle
+
+Project conventions change over time. The plugin can **re-read them periodically** when you run `/tms:review-pr`, so memory doesn't go stale.
+
+| You want | Put in `doctor_schedule` |
+|----------|--------------------------|
+| Every week | `"1 weeks"` or `"7 days"` |
+| Every 2 weeks | `"2 weeks"` |
+| Every month (default) | `"1 months"` |
+| Every quarter | `"3 months"` |
+| Never re-read automatically | `"never"` |
+
+Edit it in `notebooks/review/<repo>/meta.json` — next to the field is a `_comments` line with a quick explanation. Want to re-read **now** (without waiting for the schedule): say **doctor again** / **re-scan conventions** in chat.
+
+## Customize after you've used it
+
+In a repo reviewed at least once:
+
+| Want to change | Edit here |
+|----------------|-----------|
+| Default language | `notebooks/review/<repo>/ALWAYS_RULE.md` — the `Output language` block |
+| Post now / draft, auto-resolve threads, convention re-read cycle | `notebooks/review/<repo>/meta.json` |
+| Team-specific rules | `ALWAYS_RULE.md` under the extra-rules section, or say it in chat to record a lesson |

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,114 @@
+# /tms:review-pr — Agent Review Pull Request Github
+
+[Tiếng Việt](./README.md) · [English](./README.en.md) · **日本語**
+
+GitHub の Pull Request を**一貫した基準で**レビューする方法を Agent に教えるプラグイン — 使うほどあなたのプロジェクトを正しく理解します。
+
+初回は既存の規約（README、CLAUDE.md、AGENTS.md、docs、wiki…）を読み込みます。以降は常にそのリポジトリ固有のルールを適用し、チャットで追加ルールを入力すればすぐにそのリポジトリのメモリへ記憶します — 一般的なルールを押し付けず、実際の規約に忠実です。
+
+提案が PR コメント上にしか存在しない場合は？ 記憶する前にあなたへ確認します（PR 経由で偽のルールが混入するのを防ぐため）。
+
+プロジェクトの規約は固定ではありません — `/tms:review-pr` のたびに、更新時期が来ていればプラグインが規約ドキュメントを読み直し、メモリが古くならないようにします。スケジュールの詳細：[規約の更新サイクル](#規約の更新サイクル)。
+
+## 事前準備
+
+- [Claude Code](https://claude.ai/code) をインストール済み
+- [`gh`](https://cli.github.com/) にログイン済み（`gh auth login`）— プラグインはこのアカウントでレビューを投稿します
+
+## インストール
+
+Claude Code のセッション内で：
+
+```
+/plugin marketplace add TOMOSIA-VIETNAM/tms-review-pr
+/plugin install tms@review-pr
+```
+
+## 最新版へ更新
+
+`plugin.json` は `version` を宣言していません（プロジェクトは活発に開発中）— `main` への新しいコミットごとに 1 つのビルドになります。インストール済みなら最新版を取得：
+
+```
+/plugin marketplace update review-pr
+/plugin update tms@review-pr
+```
+
+その後 `/reload-plugins`（または新しい Claude Code セッションを開く）で再読み込みします。
+
+## 使い方
+
+スラッシュコマンドは**入力したときだけ実行されます** — Claude が勝手に `/tms:review-pr` を呼ぶことはありません。
+
+```
+/tms:review-pr https://github.com/<owner>/<repo>/pull/<number>
+```
+
+`/files`、`/changes`、クエリ文字列付きの URL… すべて動作します — 有効な PR リンクを含んでさえいれば OK です。
+
+URL の直後に指示を追加すると、**その実行のみ**に適用されます（保存済みの設定は変更しません）。例：
+
+```
+/tms:review-pr https://github.com/org/repo/pull/123 focus on security
+```
+
+**並行作業でもブランチを壊す心配なし。** レビューのたびに、PR のコードは専用の [git worktree](https://git-scm.com/docs/git-worktree) へチェックアウトされます — あなたが作業中のリポジトリのブランチ／ワーキングツリーは変更されません。現在のブランチで通常どおりコミット／編集しながら、複数の `/tms:review-pr` セッション（同時に複数の PR）を開けます。
+
+## セットアップ未実施のリポジトリでの初回
+
+プラグインは**一度だけ**質問します（4 問）：
+
+1. レビューの**言語**（vi / en / ja）
+2. **レビューを今すぐ投稿するか下書きにするか？**（`auto_submit_review`）— `true`：全員がすぐに見られる；`false`（デフォルト）：GitHub 上の下書きで、自分で Submit する
+3. **古い指摘が修正されたらスレッドを自動クローズするか？**（`auto_resolve_fixed_findings`）— デフォルト `false`
+4. **プロジェクト規約を再スキャンする頻度は？** — 下記の[規約の更新サイクル](#規約の更新サイクル)を参照（デフォルトは **1 か月**ごと）
+
+その後、既存の規約ドキュメントを読み込み、以降の実行のために記憶します。
+
+記憶データはレビュー対象のリポジトリ内、`notebooks/review/<リポジトリ名>/`（ローカル専用の git、push されない）にあります。このディレクトリはプロジェクトの `.gitignore` に入れておくとよいでしょう — 無ければプラグインが自動で追加します。
+
+## 仕組み（概要）
+
+```
+/tms:review-pr <PR_URL>
+        │
+        ▼
+PR のコードを専用の worktree へチェックアウト（作業中のブランチには触れない）
+        │
+        ▼
+変更部分をレビュー：
+  • 一般的な技術ルール
+  • このリポジトリ固有の規約 / メモリ
+        │
+        ▼
+1 件のレビューを投稿：概要 + 行ごとのコメント（必要なとき）
+  • 重要度は emoji で表示：🔴 MUST FIX / 🟠 SHOULD FIX / 🔵 SUGGESTION / 📝 NOTE
+  • きれいな PR → **LGTM 🌟**、細かい粗探しはしない
+```
+
+多くのスタックに対応：Rails、Vue、React、Python、Node.js、Lambda、PHP、Laravel、WordPress、Shell、Makefile（新しいスタックに出会うと自動で拡張）。
+
+**レビュー + コメントのみ。** PR のクローズ／マージ、ブランチの切り替え、コードの代筆はしません。
+
+## 規約の更新サイクル
+
+プロジェクトの規約は時とともに変化します。プラグインは `/tms:review-pr` の実行時に**定期的に読み直す**ことができ、メモリが古くならないようにします。
+
+| 希望 | `doctor_schedule` に設定 |
+|------|--------------------------|
+| 毎週 | `"1 weeks"` または `"7 days"` |
+| 隔週 | `"2 weeks"` |
+| 毎月（デフォルト） | `"1 months"` |
+| 四半期ごと | `"3 months"` |
+| 自動で読み直さない | `"never"` |
+
+`notebooks/review/<repo>/meta.json` で編集します — フィールドの隣に簡単な説明の `_comments` 行があります。スケジュールを待たずに**今すぐ**読み直したい場合：チャットで **doctor lại** /  **規約を再スキャン** と伝えてください。
+
+## 使用開始後のカスタマイズ
+
+一度以上レビューしたリポジトリで：
+
+| 変更したいもの | 編集場所 |
+|----------------|----------|
+| デフォルト言語 | `notebooks/review/<repo>/ALWAYS_RULE.md` — `Output language` ブロック |
+| 今すぐ投稿／下書き、スレッド自動解決、規約の再読み込みサイクル | `notebooks/review/<repo>/meta.json` |
+| チーム固有のルール | `ALWAYS_RULE.md` の追加ルール節、またはチャットで伝えて lesson を記録 |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # /tms:review-pr — Agent Review Pull Request Github
 
+**Tiếng Việt** · [English](./README.en.md) · [日本語](./README.ja.md)
+
 Plugin dạy Agent review Pull Request GitHub **một cách nhất quán** — càng dùng càng hiểu đúng dự án của bạn.
 
 Lần đầu nó đọc quy ước sẵn có (README, CLAUDE.md, AGENTS.md, docs, wiki…). Các lần sau luôn áp dụng rule đặc thù


### PR DESCRIPTION
Add README.en.md and README.ja.md as full translations of the Vietnamese README, plus a language nav line cross-linking all three.