### PR TITLE
fix(review-pr): re-review không thừa/không kể lể + tách guard diff to khỏi orchestrator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,10 @@ file này và bỏ ghi chú trạng thái git này._
 `submodule-review.md`) → detect stack → setup có điều kiện → local template → nạp ALWAYS_RULE
 LOCAL + memory + template → hard gate `re-review.md` / `pr-template-checklist.md` → review 6 mục →
 định dạng → 1 POST review PR chính (+ POST submodule nếu case). Happy path Bước 9 đủ schema inline;
-POST lỗi hoặc verify lệch → hard gate `post-review.md`. Bước 10: memory/doctor ngoài luồng review
+POST lỗi hoặc verify lệch → hard gate `post-review.md`. **Re-review mà vòng này không có gì mới
+(không finding FILE/LINE mới, không nội dung overview-only mới) → bỏ hẳn Bước 8/9, chỉ có reply
+từ Bước 6, không post review overview thừa** (xem gate đầu Bước 8) — tránh lặp lại nội dung đã reply
+riêng từng thread. Bước 10: memory/doctor ngoài luồng review
 thuần (chat ghi lesson ngay; comment PR phải hỏi; "doctor lại"; "đổi cấu hình review" — xem
 cấu hình đang áp dụng + sửa trực tiếp `meta.json`/ngôn ngữ, không đợi review kế) — nằm trong
 `review-pr.md`, không trong seed `ALWAYS_RULE` (user không customize hành vi này).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,10 @@ LOCAL + memory + template → hard gate `re-review.md` / `pr-template-checklist.
 định dạng → 1 POST review PR chính (+ POST submodule nếu case). Happy path Bước 9 đủ schema inline;
 POST lỗi hoặc verify lệch → hard gate `post-review.md`. **Re-review mà vòng này không có gì mới
 (không finding FILE/LINE mới, không nội dung overview-only mới) → bỏ hẳn Bước 8/9, chỉ có reply
-từ Bước 6, không post review overview thừa** (xem gate đầu Bước 8) — tránh lặp lại nội dung đã reply
-riêng từng thread. Bước 10: memory/doctor ngoài luồng review
+từ Bước 6, không post review overview thừa** — logic gate này sống trong `re-review.md` (đã `Read`
+ở Bước 6, đúng nguyên tắc case gắn trigger riêng, tránh nhồi thêm điều kiện re-review-specific vào
+Bước 8 luôn-nạp mà PR review lần đầu không cần tới), `review-pr.md` Bước 8 chỉ giữ 2 dòng con trỏ
+tới đó. Bước 10: memory/doctor ngoài luồng review
 thuần (chat ghi lesson ngay; comment PR phải hỏi; "doctor lại"; "đổi cấu hình review" — xem
 cấu hình đang áp dụng + sửa trực tiếp `meta.json`/ngôn ngữ, không đợi review kế) — nằm trong
 `review-pr.md`, không trong seed `ALWAYS_RULE` (user không customize hành vi này).
@@ -206,7 +208,7 @@ với 1 trigger riêng CỦA PR ĐANG REVIEW — `review-pr.md` chỉ `Read` fil
 không bao giờ tốn context cho case không áp dụng. Hiện có:
 
 - `re-review.md` — trigger: PR đã có comment review cũ (fetch 1 lần ở block "Ngữ cảnh", dùng ở
-  Bước 6). Gồm 2 việc dùng chung dữ liệu đã fetch: đề xuất 1 lesson convention mới nếu phát hiện
+  Bước 6). Gồm 3 việc: đề xuất 1 lesson convention mới nếu phát hiện
   đồng thuận trong reply chain của thread (CHỜ user xác nhận trong chat trước khi ghi — comment PR
   không tự tin cậy, tránh nhét rule giả; khác góp ý trong chat session → ghi ngay), VÀ
   kiểm tra finding cũ do chính lệnh này để lại (lọc comment top-level của tài khoản đang chạy lệnh,
@@ -217,7 +219,9 @@ không bao giờ tốn context cho case không áp dụng. Hiện có:
   `auto_resolve_fixed_findings` (xem cấu hình bên dưới) để quyết định có resolve thread qua GraphQL
   (`resolveReviewThread`, REST không hỗ trợ resolve) hay chỉ reply; chưa fix thì không làm gì,
   không nhắc lại — nhưng ghi nhớ `<path>` + mô tả để Bước 7 loại trừ, không tạo lại finding trùng
-  cho đúng vấn đề đang có thread mở.
+  cho đúng vấn đề đang có thread mở. VÀ (việc thứ 3) gate dừng sớm ở Bước 8: sau khi Bước 7 review
+  xong, vòng này không có gì mới (không finding FILE/LINE mới, không nội dung overview-only mới) →
+  bỏ hẳn Bước 8/9, không post review overview thừa lên nội dung đã reply riêng từng thread ở trên.
 - `pr-template-checklist.md` — trigger: repo có file dạng `.github/PULL_REQUEST_TEMPLATE.md` (phát
   hiện 1 lần lúc doctor, cache tại `meta.json.pr_template_paths`, dùng ở Bước 7). Đối chiếu
   description thật của PR với checklist trong template đó, gộp mọi mục còn thiếu/chưa tick thành

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,11 @@ Nhãn 3 mức nghiêm trọng dùng emoji ASCII thay text: 🔴 MUST FIX (Bắt 
 của chính mình, KHÔNG phụ thuộc hình dạng prose (đổi format Bước 7 sau này không làm gãy detection).
 
 **Guard file to/dump (byte size, `big_file_threshold_kb`) VÀ guard nhiều file (số lượng,
-`many_files_threshold`) là 2 cơ chế riêng, có thể chồng nhau.** File vượt `many_files_threshold` VÀ
+`many_files_threshold`) là 2 cơ chế riêng, có thể chồng nhau — cả 2 sống trong
+`src/cases/large-diff-guards.md`, không inline trong `review-pr.md` nữa** (đúng nguyên tắc case
+gắn 1 trigger riêng — 2 guard này chỉ áp dụng cho thiểu số PR vượt ngưỡng, đa số PR nhỏ không cần
+tốn context đọc hết chi tiết chiến lược a/b/c + checklist chống quên mỗi lần review; `review-pr.md`
+Bước 7 chỉ còn 2 dòng hard-gate boolean trỏ tới file case). File vượt `many_files_threshold` VÀ
 chọn chiến lược (a) "review nông" VÀ CŨNG vượt ngưỡng size/dump (`big_file_threshold_kb`, default
 `20` KB ~ 5.000 token) → 2 rule đá nhau (a) cấm đọc thêm, guard size/dump lại cần peek để phân loại —
 xử lý bằng cách HỎI user 1 câu gộp (không hỏi riêng từng file) muốn peek hay bỏ qua, agent có quyền
@@ -247,6 +251,12 @@ không bao giờ tốn context cho case không áp dụng. Hiện có:
 - `post-review.md` — trigger: POST review lỗi **hoặc** verify `state` lệch kỳ vọng
   `auto_submit_review`. Retry 1 lần theo schema; cấm comment/review test trên PR thật; nhánh
   submit-events khi `true` mà vẫn PENDING. Happy path không đọc file này.
+- `large-diff-guards.md` — trigger: PR đổi > `many_files_threshold` file HOẶC có file "Size diff
+  theo file" (Ngữ cảnh) > `big_file_threshold_kb` KB/`UNKNOWN` (2 điều kiện độc lập, dùng ở Bước 7).
+  Guard số lượng file: hỏi chiến lược review (a nông toàn bộ / b sâu chọn lọc / c dừng đề nghị tách
+  PR) + checklist chống quên file. Guard file to/dump: peek có giới hạn phân loại data/dump-vs-logic
+  thật, ghi `.review-skipped.md`. 2 guard tương tác khi PR khớp CẢ 2 VÀ user chọn (a) — gộp 1 câu hỏi
+  duy nhất có peek size/dump hay bỏ qua luôn.
 
 Thư mục này CHỦ Ý để MỞ RỘNG: case mới = hard gate boolean + 1 file, không nhét vào `review-pr.md`.
 
@@ -297,12 +307,12 @@ token — ước lượng ~4 ký tự/token).
   chưa có CI). Được hỏi thì mặc định `true` nếu user không chọn. Chi phối Bước 7: `true` → CI check
   fail (lọc `bucket=="fail"` từ mảng đã fetch) hiện thành 1 câu cảnh báo trong overview, không tính
   severity; `false` → bỏ qua hoàn toàn, không tham chiếu data đó dù đã có trong Ngữ cảnh.
-- `many_files_threshold` chi phối guard đầu Bước 7: PR đổi nhiều file hơn ngưỡng này (default `30`)
-  → hỏi chiến lược review (nông toàn bộ / sâu chọn lọc / dừng đề nghị tách PR), trừ khi
-  ARGUMENTS/chat đã chỉ định sẵn.
-- `big_file_threshold_kb` chi phối guard size/dump ở Bước 7: file có diff vượt ngưỡng này tính bằng
-  KB (default `20`), hoặc `UNKNOWN` (GitHub bỏ patch vì quá lớn) → peek có giới hạn để phân loại
-  data/dump thay vì review chi tiết dòng-by-dòng.
+- `many_files_threshold` chi phối trigger đầu Bước 7 vào `large-diff-guards.md`: PR đổi nhiều file
+  hơn ngưỡng này (default `30`) → hỏi chiến lược review (nông toàn bộ / sâu chọn lọc / dừng đề nghị
+  tách PR), trừ khi ARGUMENTS/chat đã chỉ định sẵn.
+- `big_file_threshold_kb` chi phối trigger đầu Bước 7 vào `large-diff-guards.md`: file có diff vượt
+  ngưỡng này tính bằng KB (default `20`), hoặc `UNKNOWN` (GitHub bỏ patch vì quá lớn) → peek có
+  giới hạn để phân loại data/dump thay vì review chi tiết dòng-by-dòng.
 - `auto_resolve_fixed_findings` chi phối nhánh finding đã fix trong `re-review.md`.
 - **Repo đã bootstrap TRƯỚC KHI 1 field cấu hình ra đời** (vd repo cũ review trước khi
   `review_ci_status`/`many_files_threshold`/`big_file_threshold_kb` xuất hiện) — Phần A KHÔNG tự

--- a/src/cases/large-diff-guards.md
+++ b/src/cases/large-diff-guards.md
@@ -1,0 +1,81 @@
+# Large diff guards — nhiều file / file to-dump (Bước 7 `review-pr.md`)
+
+Không phải slash command (nằm ngoài `commands/`). `review-pr.md` Bước 7 `Read` file này khi PR đang
+review khớp ÍT NHẤT 1 trong 2 điều kiện độc lập dưới đây — không khớp điều kiện nào thì không đọc
+file này, Bước 7 diễn ra bình thường, không gì trong file này áp dụng:
+
+- **Guard số lượng file**: đếm số file trong "Files" (Ngữ cảnh, `--name-only`, mỗi dòng 1 file) >
+  `many_files_threshold` (Bước 3 `review-pr.md`, default `30`).
+- **Guard file to/dump**: ít nhất 1 file có "Size diff theo file" (Ngữ cảnh) >
+  `big_file_threshold_kb` KB (Bước 3, default `20`), hoặc `UNKNOWN` (GitHub bỏ patch vì quá lớn).
+
+2 guard độc lập, PR có thể chỉ khớp 1 trong 2 (vd 5 file nhưng 1 file cực to → chỉ guard file
+to/dump áp dụng, bỏ qua hẳn phần "Guard số lượng file" dưới) — chỉ phần "Tương tác 2 guard" cuối
+file mới cần CẢ 2 khớp cùng lúc.
+
+## Guard số lượng file
+
+- `ARGUMENTS`/chat lúc gọi lệnh ĐÃ chỉ định chiến lược (vd "review nông", "review sâu chọn lọc",
+  "dừng") → dùng luôn, KHÔNG hỏi lại.
+- CHƯA chỉ định → DỪNG, hỏi user ngay trong chat, đưa đúng 3 lựa chọn, CHỜ reply, KHÔNG tự chọn mặc
+  định:
+  ```
+  PR này đổi <N> file (> <ngưỡng>) — review sâu hết dễ tốn effort lớn/dễ sót. Chọn 1 chiến lược:
+  (a) Review nông toàn bộ — lướt hết mọi file, giảm độ sâu, chỉ bắt lỗi rõ ràng ngay trên diff.
+  (b) Review sâu có chọn lọc — sâu ở file logic thật, lướt nhẹ file config/generated/test.
+  (c) Dừng — nêu lý do, đề nghị dev tách PR nhỏ hơn, không review.
+  ```
+- Chọn **(a)**: toàn bộ Bước 7 (`review-pr.md`) vẫn áp dụng cho MỌI file, nhưng bỏ mục "Đọc thêm
+  tại `<worktree>/<path>` khi cần" — chỉ dựa vào diff Ngữ cảnh, không tự ý đọc thêm context ngoài
+  diff. Xem "Tương tác 2 guard" dưới nếu PR CŨNG khớp guard file to/dump.
+- Chọn **(b)**: dùng kết quả Bước 2 `review-pr.md` (stack detect) phân loại — file LOGIC thật (code
+  nghiệp vụ theo stack) review ĐẦY ĐỦ theo mọi rule Bước 7 bình thường; file config/lock/generated/
+  test (phán đoán ngữ cảnh — ví dụ minh họa, không checklist đóng) → gộp finding nhẹ/lướt, không mổ
+  dòng-by-dòng.
+- Chọn **(c)**: KHÔNG chạy Bước 7 (phần review thật) → Bước 9 `review-pr.md`. Chat-only: nêu số file
+  + ngưỡng, đề nghị dev tách PR, DỪNG lệnh hẳn — không post gì lên GitHub (giống early-exit ở Bước 0
+  `review-pr.md`).
+
+**Checklist chống quên file** (chỉ khi chọn (a)/(b) ở trên — KHÔNG áp dụng cho (c) vì không review
+gì):
+
+1. Ngay khi chọn (a)/(b): `Write` `<worktree>/.review-checklist.md` — mỗi file trong "Files" (Ngữ
+   cảnh) 1 dòng `- [ ] <path>`. File này CHỈ là sổ tay nội bộ — không bao giờ xuất hiện trong PR
+   body hay output chat.
+2. Review xong 1 file (có finding hay không cũng tính là "xong") → `Edit` đúng dòng đó thành
+   `- [x] <path>`.
+3. **BẮT BUỘC, không bỏ qua** — TRƯỚC KHI viết Bước 8 `review-pr.md`: `Read` lại
+   `.review-checklist.md` VÀ `.review-skipped.md` (nếu có). Dòng nào còn `[ ]` trong checklist VÀ
+   KHÔNG có mặt trong `.review-skipped.md` → đây là file bị QUÊN thật (không phải chủ động skip) —
+   quay lại review NGAY file đó trước khi tổng hợp, tuyệt đối không để lộ ra ngoài dưới dạng thiếu
+   sót âm thầm.
+
+## Guard file to/dump
+
+Với MỖI file khớp điều kiện "Guard file to/dump" ở đầu file này: peek CÓ GIỚI HẠN (`Read`
+offset/limit ~30-50 dòng đầu hunk, không đọc hết) để phán đoán data/seed/dump/generated (lặp cấu
+trúc, toàn literal, không control flow) hay logic thật tình cờ đổi nhiều:
+
+- **Data/dump/generated** → KHÔNG review chi tiết dòng-by-dòng, KHÔNG paste lại nội dung dump vào
+  finding; đúng 1 finding cấp FILE (thường 📝 NOTE hoặc 🔵 SUGGESTION) nêu "diff lớn — có vẻ
+  seed/dump data, xác nhận đúng ý chưa". Ghi lại `<path>` + lý do vào `<worktree>/.review-skipped.md`
+  (1 dòng `- <path> — <lý do>` mỗi entry, `Write` nếu file chưa có/`Edit` append nếu đã có) — LUÔN
+  ghi vào file này, không chỉ trong context (đây là anchor thật, không phải nhớ tạm) — dùng để liệt
+  kê ở Bước 8 `review-pr.md` và đối chiếu ở checklist chống quên trên.
+- **Logic thật (chỉ tình cờ to)** → review bình thường, đọc tiếp theo từng đoạn (offset/limit như
+  trên), không `Read` trọn patch 1 lần.
+
+## Tương tác 2 guard — chọn (a) VÀ CŨNG khớp guard file to/dump
+
+Chỉ áp dụng khi PR khớp CẢ 2 điều kiện ở đầu file này VÀ user vừa chọn chiến lược (a) ở "Guard số
+lượng file". Liệt kê ĐÚNG các file khớp "Guard file to/dump" ngay sau khi user chọn (a) — gộp thành
+1 câu hỏi DUY NHẤT (không hỏi riêng từng file), hỏi user muốn peek để phân loại data/dump-vs-logic-
+thật hay bỏ qua luôn:
+
+- User đồng ý (tất cả hoặc chỉ định file cụ thể) → peek CÓ GIỚI HẠN đúng quy tắc "Guard file to/dump"
+  trên, CHỈ cho các file đó; phần còn lại của PR vẫn theo (a) bình thường.
+- User từ chối/không trả lời rõ → không đọc, ghi vào `.review-skipped.md` (xem checklist trên) lý do
+  "chiến lược (a) + size lớn, user chọn không review — tự xem".
+- File QUÁ lớn để peek an toàn dù user đồng ý (vd size vượt xa ngưỡng, hoặc `UNKNOWN` mà thực tế cực
+  lớn) → agent có thể TỪ CHỐI peek, khuyên user nên bỏ qua để tránh vỡ context, ghi vào
+  `.review-skipped.md` tương tự.

--- a/src/cases/re-review.md
+++ b/src/cases/re-review.md
@@ -56,8 +56,16 @@ Mục tiêu riêng, khác việc học convention ở trên:
      - **`false`** → CHỈ reply như trên, KHÔNG gọi GraphQL resolve — thread giữ nguyên trạng thái
        chưa resolve, để user tự resolve trên GitHub nếu muốn.
    - **Chưa fix** → KHÔNG làm gì cả, giữ nguyên comment, không nhắc lại, không tạo thêm nội dung gì.
-     **Ghi nhớ `<path>` + mô tả ngắn của finding này (còn mở, chưa fix)** — Bước 7 `review-pr.md`
-     dùng danh sách này để loại trừ, tránh tạo lại finding trùng cho đúng vấn đề đang có thread mở.
+     **Ghi nhớ `<path>` + mô tả ngắn của finding này (còn mở, chưa fix)** — dùng ngay ở mục dưới để
+     Bước 7 `review-pr.md` loại trừ, tránh tạo lại finding trùng cho đúng vấn đề đang có thread mở.
+
+## Không tạo lại finding trùng ở Bước 7
+
+Trong lúc Bước 7 `review-pr.md` review diff của lần cập nhật này: với MỖI finding cũ CHƯA fix đã
+ghi nhớ ở mục trên, nếu vấn đề đang thấy ở Bước 7 là ĐÚNG vấn đề đó (cùng path, cùng bản chất lỗi) →
+KHÔNG tạo finding mới cho nó, để nguyên thread cũ (đã đang mở, không cần lặp lại). Vấn đề THẬT SỰ
+khác (khác path, hoặc cùng path nhưng lỗi khác hẳn) → vẫn tạo finding mới bình thường, không liên
+quan gì tới rule này.
 
 ## Gate dừng sớm ở Bước 8 — không phải lúc nào re-review cũng cần overview
 

--- a/src/cases/re-review.md
+++ b/src/cases/re-review.md
@@ -59,6 +59,9 @@ Mục tiêu riêng, khác việc học convention ở trên:
      **Ghi nhớ `<path>` + mô tả ngắn của finding này (còn mở, chưa fix)** — Bước 7 `review-pr.md`
      dùng danh sách này để loại trừ, tránh tạo lại finding trùng cho đúng vấn đề đang có thread mở.
 
+Reply ở đây KHÔNG tự động kéo theo phải post thêm 1 review overview — nếu vòng review này không có
+gì mới, `review-pr.md` Bước 8 sẽ bỏ hẳn Bước 9, không post gì thêm (xem gate đầu Bước 8).
+
 ## Reaction lên reply của dev (bổ sung, không bắt buộc)
 
 Trong danh sách comment đã fetch, nếu thread của finding (mục trên) có reply từ DEV (`user.login`

--- a/src/cases/re-review.md
+++ b/src/cases/re-review.md
@@ -59,8 +59,18 @@ Mục tiêu riêng, khác việc học convention ở trên:
      **Ghi nhớ `<path>` + mô tả ngắn của finding này (còn mở, chưa fix)** — Bước 7 `review-pr.md`
      dùng danh sách này để loại trừ, tránh tạo lại finding trùng cho đúng vấn đề đang có thread mở.
 
-Reply ở đây KHÔNG tự động kéo theo phải post thêm 1 review overview — nếu vòng review này không có
-gì mới, `review-pr.md` Bước 8 sẽ bỏ hẳn Bước 9, không post gì thêm (xem gate đầu Bước 8).
+## Gate dừng sớm ở Bước 8 — không phải lúc nào re-review cũng cần overview
+
+Reply ở mục trên KHÔNG tự động kéo theo phải post thêm 1 review overview. Sau khi Bước 7
+`review-pr.md` chạy xong (review diff của lần cập nhật này), kiểm tra: có finding FILE/LINE nào MỚI
+không, có mục nào trong "Overview" ở Bước 7 MỚI phát sinh không (title/body mập mờ mới, CI check
+fail mới, PR template checklist mới thiếu), danh sách file bị skip có entry MỚI không.
+
+- **KHÔNG có gì mới** (toàn bộ việc cần làm đã xử lý xong bằng reply/resolve ở mục trên rồi) → **bỏ
+  hẳn Bước 8/9, DỪNG lệnh ở đây, KHÔNG post gì thêm lên PR chính.** Reply đã có là đủ giá trị; thêm 1
+  review overview lặp lại nội dung đã reply riêng từng thread là dư thừa, gây nhiễu cho người nhận.
+- **Có ít nhất 1 thứ MỚI** → tiếp tục Bước 8/9 bình thường, NHƯNG phần đánh giá chung CHỈ nói về
+  phần MỚI/thay đổi lần này, không lặp lại toàn bộ đánh giá tổng thể đã nói ở review trước.
 
 ## Reaction lên reply của dev (bổ sung, không bắt buộc)
 

--- a/src/commands/review-pr.md
+++ b/src/commands/review-pr.md
@@ -19,6 +19,12 @@ description: Review 1 PR GitHub đa stack, học convention riêng theo repo qua
 > `Read`/`Grep` file trong worktree có thể khiến Claude Code tự phát hiện `.claude/skills/` nested
 > của CHÍNH repo đang review — đó là skill phục vụ DEV repo đó, KHÔNG phải công cụ review; CẤM tự
 > invoke, dù được liệt trong danh sách skill khả dụng.
+> **Tường thuật tiến trình trong chat lúc thực thi — KHÔNG lộ số bước nội bộ ("Bước 6", "Bước 7"...)
+> ra ngoài.** "Bước 0-10" là cấu trúc nội bộ CỦA FILE NÀY để tổ chức logic, người dùng theo dõi
+> tiến trình không biết số đó nghĩa là gì. Khi cần thông báo đang làm gì, diễn đạt bằng việc THẬT
+> đang làm (vd "Đang kiểm tra comment review cũ...", "Đang review code theo convention...", "Đang
+> tổng hợp kết quả..."), không nhắc tên/số bước.
+
 
 ## Bước 0 — Validate ARGUMENTS
 

--- a/src/commands/review-pr.md
+++ b/src/commands/review-pr.md
@@ -156,56 +156,12 @@ Comments từ Ngữ cảnh:
 
 ## Bước 7 — Review
 
-**Guard số lượng file (làm TRƯỚC mọi việc khác trong bước này):**
-
-Đếm số file trong "Files" (Ngữ cảnh, `--name-only`, mỗi dòng 1 file). So với
-`many_files_threshold` (Bước 3, default `30`).
-
-- ≤ ngưỡng → bỏ qua, review bình thường theo phần dưới.
-- \> ngưỡng:
-  - `ARGUMENTS`/chat lúc gọi lệnh ĐÃ chỉ định chiến lược (vd "review nông", "review sâu chọn lọc",
-    "dừng") → dùng luôn, KHÔNG hỏi lại.
-  - CHƯA chỉ định → DỪNG, hỏi user ngay trong chat, đưa đúng 3 lựa chọn, CHỜ reply, KHÔNG tự chọn
-    mặc định:
-    ```
-    PR này đổi <N> file (> <ngưỡng>) — review sâu hết dễ tốn effort lớn/dễ sót. Chọn 1 chiến lược:
-    (a) Review nông toàn bộ — lướt hết mọi file, giảm độ sâu, chỉ bắt lỗi rõ ràng ngay trên diff.
-    (b) Review sâu có chọn lọc — sâu ở file logic thật, lướt nhẹ file config/generated/test.
-    (c) Dừng — nêu lý do, đề nghị dev tách PR nhỏ hơn, không review.
-    ```
-  - Chọn **(a)**: toàn bộ Bước 7 dưới đây vẫn áp dụng cho MỌI file, nhưng bỏ mục "Đọc thêm tại
-    `<worktree>/<path>` khi cần" — chỉ dựa vào diff Ngữ cảnh, không tự ý đọc thêm context ngoài diff.
-    **Ngoại lệ — file trùng CẢ (a) VÀ guard size/dump** (mục "Size diff theo file" ở Ngữ cảnh >
-    `big_file_threshold_kb` KB (Bước 3, default `20`) hoặc `UNKNOWN`, xem "Phạm vi" dưới): liệt kê
-    ĐÚNG các file này ngay sau khi user chọn (a) —
-    gộp thành 1 câu hỏi DUY NHẤT (không hỏi riêng từng file), hỏi user muốn peek để phân loại
-    data/dump-vs-logic-thật hay bỏ qua luôn:
-    - User đồng ý (tất cả hoặc chỉ định file cụ thể) → peek CÓ GIỚI HẠN đúng quy tắc size/dump ở
-      "Phạm vi" dưới, CHỈ cho các file đó; phần còn lại của PR vẫn theo (a) bình thường.
-    - User từ chối/không trả lời rõ → không đọc, ghi vào `.review-skipped.md` (xem checklist dưới)
-      lý do "chiến lược (a) + size lớn, user chọn không review — tự xem".
-    - File QUÁ lớn để peek an toàn dù user đồng ý (vd size vượt xa ngưỡng, hoặc `UNKNOWN` mà thực
-      tế cực lớn) → agent có thể TỪ CHỐI peek, khuyên user nên bỏ qua để tránh vỡ context, ghi vào
-      `.review-skipped.md` tương tự.
-  - Chọn **(b)**: dùng kết quả Bước 2 (stack detect) phân loại — file LOGIC thật (code nghiệp vụ
-    theo stack) review ĐẦY ĐỦ theo mọi rule Bước 7 bình thường; file config/lock/generated/test
-    (phán đoán ngữ cảnh — ví dụ minh họa, không checklist đóng) → gộp finding nhẹ/lướt, không mổ
-    dòng-by-dòng.
-  - Chọn **(c)**: KHÔNG chạy Bước 7 (phần dưới) → Bước 9. Chat-only: nêu số file + ngưỡng, đề nghị
-    dev tách PR, DỪNG lệnh hẳn — không post gì lên GitHub (giống early-exit ở Bước 0).
-
-**Checklist chống quên file (chỉ khi vượt ngưỡng ở trên — PR nhỏ khỏi cần, tự nhớ đủ; áp dụng cho
-CẢ (a) và (b), KHÔNG áp dụng cho (c) vì không review gì):**
-
-1. Ngay khi chọn (a)/(b): `Write` `<worktree>/.review-checklist.md` — mỗi file trong "Files" (Ngữ
-   cảnh) 1 dòng `- [ ] <path>`. File này CHỈ là sổ tay nội bộ — không bao giờ xuất hiện trong PR
-   body hay output chat.
-2. Review xong 1 file (có finding hay không cũng tính là "xong") → `Edit` đúng dòng đó thành
-   `- [x] <path>`.
-3. **BẮT BUỘC, không bỏ qua** — TRƯỚC KHI viết Bước 8: `Read` lại `.review-checklist.md` VÀ
-   `.review-skipped.md` (nếu có). Dòng nào còn `[ ]` trong checklist VÀ KHÔNG có mặt trong
-   `.review-skipped.md` → đây là file bị QUÊN thật (không phải chủ động skip) — quay lại review
-   NGAY file đó trước khi tổng hợp, tuyệt đối không để lộ ra ngoài dưới dạng thiếu sót âm thầm.
+**Guard diff to (làm TRƯỚC mọi việc khác trong bước này):** đếm số file trong "Files" (Ngữ cảnh,
+`--name-only`) so với `many_files_threshold` (Bước 3, default `30`), VÀ kiểm mục "Size diff theo
+file" (Ngữ cảnh) có entry nào > `big_file_threshold_kb` KB (Bước 3, default `20`) hoặc `UNKNOWN`
+không. Khớp ÍT NHẤT 1 trong 2 → `Read` `"${CLAUDE_PLUGIN_ROOT}"/cases/large-diff-guards.md`, làm
+theo (có thể dừng hẳn lệnh ở đó nếu user chọn "dừng"). Không khớp cả 2 → bỏ qua, review bình thường
+theo phần dưới.
 
 **Overview (không tính N, không vào `comments[]`):**
 
@@ -235,29 +191,13 @@ FILE vào `comments[]`.
 
 **Phạm vi:**
 
-- **Không tạo lại finding trùng vấn đề đã có thread cũ còn mở (Bước 6).** Nếu Bước 6 vừa xác định
-  1 finding cũ CHƯA fix (đã ghi nhớ `<path>` + mô tả ở `re-review.md`), và vấn đề đang thấy ở đây
-  là ĐÚNG vấn đề đó (cùng path, cùng bản chất lỗi) → KHÔNG tạo finding mới cho nó, để nguyên thread
-  cũ (đã đang mở, không cần lặp lại). Vấn đề THẬT SỰ khác (khác path, hoặc cùng path nhưng lỗi khác
-  hẳn) → vẫn tạo finding mới bình thường, không liên quan gì tới rule này.
 - Ưu tiên thay đổi in-scope; out-of-scope hoặc chưa cần fix ngay → nhãn 📝 NOTE, không ép fix,
   không tính vào 3 mức nghiêm trọng.
 - Đọc thêm tại `<worktree>/<path>` khi cần; không bắt buộc — nhưng LUÔN dùng `offset`/`limit` của
   `Read` khoanh theo vùng đổi (lấy dòng bắt đầu từ hunk header diff `@@ -a,b +c,d @@` ± ~20-30 dòng
   buffer), CẤM `Read` trần không offset/limit trên file có thay đổi cục bộ (không phải file mới/bị
-  viết lại toàn bộ) — file to mà PR chỉ sửa 1 đoạn nhỏ thì không cần nuốt cả file.
-- File có size diff (mục "Size diff theo file" ở Ngữ cảnh) **> `big_file_threshold_kb` KB (Bước 3,
-  default `20`), hoặc `UNKNOWN`** → peek CÓ GIỚI HẠN (`Read` offset/limit ~30-50 dòng đầu hunk,
-  không đọc hết) để phán đoán data/seed/dump/generated (lặp cấu trúc, toàn literal, không control
-  flow) hay logic thật tình cờ đổi nhiều:
-  - Data/dump/generated → KHÔNG review chi tiết dòng-by-dòng, KHÔNG paste lại nội dung dump vào
-    finding; đúng 1 finding cấp FILE (thường 📝 NOTE hoặc 🔵 SUGGESTION) nêu "diff lớn — có vẻ
-    seed/dump data, xác nhận đúng ý chưa". Ghi lại `<path>` + lý do vào
-    `<worktree>/.review-skipped.md` (1 dòng `- <path> — <lý do>` mỗi entry, `Write` nếu file chưa
-    có/`Edit` append nếu đã có) — **LUÔN ghi vào file này, không chỉ trong context** (đây là anchor
-    thật, không phải nhớ tạm) — dùng để liệt kê ở Bước 8 và đối chiếu ở checklist chống quên.
-  - Logic thật (chỉ tình cờ to) → review bình thường, đọc tiếp theo từng đoạn (offset/limit như
-    trên), không Read trọn patch 1 lần.
+  viết lại toàn bộ) — file to mà PR chỉ sửa 1 đoạn nhỏ thì không cần nuốt cả file (file vượt
+  `big_file_threshold_kb` → guard riêng, xem đầu Bước 7).
 - Diff Ngữ cảnh = nguồn duy nhất cho nội dung đổi — không refetch cùng diff.
 - Không đọc source thư viện trừ khi thật không chắc.
 - Không bới finding vụn. PR tốt → **LGTM 🌟**; không sàn tối thiểu N.

--- a/src/commands/review-pr.md
+++ b/src/commands/review-pr.md
@@ -150,7 +150,8 @@ xuất hiện sau bootstrap).
 
 Comments từ Ngữ cảnh:
 
-- Không rỗng → `Read` `"${CLAUDE_PLUGIN_ROOT}"/cases/re-review.md`.
+- Không rỗng → `Read` `"${CLAUDE_PLUGIN_ROOT}"/cases/re-review.md`. Đây là RE-REVIEW — ảnh hưởng
+  đến việc có post Bước 9 hay không, xem gate đầu Bước 8.
 - Rỗng → bỏ qua, sang Bước 7.
 
 ## Bước 7 — Review
@@ -288,18 +289,35 @@ LINE) → xuống dòng, mỗi ý 1 bullet `-`, không dồn thành 1 câu dài 
 
 Ngôn ngữ theo Bước 5 (session override nếu có).
 
+**Gate RE-REVIEW — không phải lúc nào re-review cũng cần overview.** Bước 6 đã chạy (PR có comment
+cũ) VÀ Bước 7 kết luận KHÔNG có gì MỚI để nói ở cấp overview — không finding FILE/LINE nào mới,
+không mục nào trong "Overview" ở Bước 7 mới phát sinh (title/body mập mờ mới, CI check fail mới, PR
+template checklist mới thiếu), danh sách file bị skip không có entry mới — nghĩa là toàn bộ việc
+cần làm đã xử lý xong bằng reply/resolve ở Bước 6 rồi → **bỏ hẳn Bước 8/9, DỪNG lệnh ở đây, KHÔNG
+post gì thêm lên PR chính.** Reply ở Bước 6 là đủ giá trị, thêm 1 review overview lặp lại nội dung
+đã reply riêng từng thread là dư thừa, gây nhiễu cho người nhận. Có ít nhất 1 thứ MỚI kể trên → tiếp
+tục Bước 8/9 bình thường, NHƯNG phần đánh giá chung dưới đây CHỈ nói về phần MỚI/thay đổi lần này,
+không lặp lại toàn bộ đánh giá tổng thể đã nói ở review trước.
+
+**Overview KHÔNG kể lại quá trình LÀM VIỆC của agent** (đã fetch/checkout gì, đối chiếu ở commit
+nào, có gọi lại API nào, có bị gián đoạn giữa chừng không...) — người review và người nhận review
+CHỈ quan tâm kết luận liên quan tới PR/commit (đã fix gì thật, còn gì mở, có gì mới), không quan
+tâm cách agent kiểm tra ra sao; quá trình làm việc là việc nội bộ của agent, không phải thông tin
+của PR, kể cả khi bị gián đoạn giữa chừng. Câu chốt tổng kết (vd "Không phát hiện vấn đề mới nào
+trong phần thay đổi lần này.") → in **đậm**, cùng cấp nhấn mạnh như **LGTM 🌟**.
+
 **CẤM trùng nội dung LINE:** body tổng quan KHÔNG lặp lại nội dung + `**Gợi ý**` của finding đã vào
 `comments[]` — LINE đã hiển thị trực quan tại đúng dòng diff trong GitHub, không liệt kê lại, không
 đếm số trong overview dưới bất kỳ hình thức nào. Chi tiết chỉ nằm inline.
 
 KHÔNG có vấn đề gì (FILE lẫn LINE) → TOÀN BỘ body CHỈ 1 DÒNG: **LGTM 🌟** — KHÔNG có heading
-"### Nhận xét tổng quan" phía trên, không câu nào khác (không cảm ơn, không đánh giá) — TRỪ mục
-"File đã bỏ qua review chi tiết" ngay dưới nếu danh sách đó không rỗng.
+"###【AI REVIEW】Nhận xét tổng quan" phía trên, không câu nào khác (không cảm ơn, không đánh giá) —
+TRỪ mục "File đã bỏ qua review chi tiết" ngay dưới nếu danh sách đó không rỗng.
 
 CÓ vấn đề → theo cấu trúc:
 
 ```
-### Nhận xét tổng quan
+###【AI REVIEW】Nhận xét tổng quan
 Mở đầu ĐÚNG cụm "Cảm ơn bạn! 🙇🏻‍♂️" (ngắn gọn — KHÔNG thêm mô tả kiểu "đã gửi PR này"/"đã bỏ công
 làm việc"), rồi 1 câu hướng dẫn reply, xưng "bạn" (KHÔNG "anh"/"chị"). Sau đó 2-3 câu đánh giá
 chung + overview title/prefix nếu có.

--- a/src/commands/review-pr.md
+++ b/src/commands/review-pr.md
@@ -289,15 +289,9 @@ LINE) → xuống dòng, mỗi ý 1 bullet `-`, không dồn thành 1 câu dài 
 
 Ngôn ngữ theo Bước 5 (session override nếu có).
 
-**Gate RE-REVIEW — không phải lúc nào re-review cũng cần overview.** Bước 6 đã chạy (PR có comment
-cũ) VÀ Bước 7 kết luận KHÔNG có gì MỚI để nói ở cấp overview — không finding FILE/LINE nào mới,
-không mục nào trong "Overview" ở Bước 7 mới phát sinh (title/body mập mờ mới, CI check fail mới, PR
-template checklist mới thiếu), danh sách file bị skip không có entry mới — nghĩa là toàn bộ việc
-cần làm đã xử lý xong bằng reply/resolve ở Bước 6 rồi → **bỏ hẳn Bước 8/9, DỪNG lệnh ở đây, KHÔNG
-post gì thêm lên PR chính.** Reply ở Bước 6 là đủ giá trị, thêm 1 review overview lặp lại nội dung
-đã reply riêng từng thread là dư thừa, gây nhiễu cho người nhận. Có ít nhất 1 thứ MỚI kể trên → tiếp
-tục Bước 8/9 bình thường, NHƯNG phần đánh giá chung dưới đây CHỈ nói về phần MỚI/thay đổi lần này,
-không lặp lại toàn bộ đánh giá tổng thể đã nói ở review trước.
+**Bước 6 đã chạy (re-review)** → áp dụng gate dừng sớm mô tả trong `re-review.md` (đã `Read` ở Bước
+6) TRƯỚC KHI tiếp tục phần dưới — có thể bỏ hẳn Bước 8/9 nếu vòng này không có gì mới. Bước 6 KHÔNG
+chạy (PR mới, chưa có comment cũ) → bỏ qua, luôn tiếp tục bình thường.
 
 **Overview KHÔNG kể lại quá trình LÀM VIỆC của agent** (đã fetch/checkout gì, đối chiếu ở commit
 nào, có gọi lại API nào, có bị gián đoạn giữa chừng không...) — người review và người nhận review


### PR DESCRIPTION
## Mô tả

2 nhóm thay đổi trên `src/commands/review-pr.md`, cả 2 đều xuất phát từ dogfood review thật
(`Bee2B/schoolphoto-infra#1`, `Bee2B/schoolphoto-web#102`) và từ soát lại kiến trúc `cases/`:

**1. Re-review không còn post overview thừa, không kể lể process**
Bước 9 từng luôn post 1 review overview mới dù re-review không có gì mới — dư thừa với reply đã để
lại riêng từng thread ở Bước 6, và overview đó còn kể lể quá trình agent tự kiểm tra ("đã
fetch/checkout lại...", "đối chiếu code ở commit...") — thông tin nội bộ, không phải nội dung PR.

**3. Không lộ số bước nội bộ ra chat**
User quan sát 1 lần chạy thật thấy agent tường thuật "giờ qua bước 6, đến bước 7" trong chat — vô nghĩa với người không đọc file này. Thêm rule tường thuật bằng việc THẬT đang làm, không nhắc số bước.

**2. Tách 2 guard diff-to khỏi orchestrator luôn-nạp**
Guard nhiều file (`many_files_threshold`) + guard file to/dump (`big_file_threshold_kb`) từng inline
~70 dòng ngay trong Bước 7 — chỉ áp dụng cho thiểu số PR vượt ngưỡng, nhưng MỌI PR (kể cả PR nhỏ)
đều phải tải qua. Vi phạm đúng nguyên tắc `cases/` mà repo tự đặt ra (case gắn 1 trigger riêng, chỉ
`Read` khi trigger đúng). Đã tách sang `src/cases/large-diff-guards.md`.

## Loại thay đổi

- [x] 🐛 Fix bug
- [x] 🔧 Chore (refactor kiến trúc, không đổi hành vi user thấy được ở phần 2)
- [ ] 🔴 Breaking change
- [ ] ✨ Feature mới
- [ ] 📝 Docs

## Thay đổi chính

- Gate re-review (đầu Bước 8, logic đầy đủ sống trong `re-review.md`): không có gì mới → bỏ hẳn
  Bước 8/9, chỉ giữ reply.
- Cấm overview kể lể process của agent; câu chốt tổng kết in đậm, cùng cấp `LGTM 🌟`.
- Label `###【AI REVIEW】Nhận xét tổng quan` đồng bộ ở chỗ tham chiếu còn sót.
- `src/cases/large-diff-guards.md` mới: guard số lượng file (chiến lược a/b/c + checklist chống
  quên) + guard file to/dump (peek phân loại data/dump) + tương tác 2 guard — Bước 7 giờ chỉ 6 dòng
  hard-gate trỏ tới file này.
- Rule "không tạo lại finding trùng thread re-review mở" dời từ Bước 7 vào `re-review.md` (cùng lý
  do — chỉ có ý nghĩa khi Bước 6 đã chạy).
- Đã kiểm riêng: rule bắt emoji severity cho LINE comment đã có sẵn trong prompt, áp dụng mọi
  stack — 1 PR dogfood thiếu emoji là lỗi tuân thủ thực thi của lần chạy đó, không phải gap trong
  prompt, không sửa gì thêm ở khoản này.

## Đã test thế nào

Đọc lại comment/review thật đã post trên 2 PR go-live nêu trên qua `gh api` để xác nhận đúng vấn đề
trước khi sửa (không đoán). Chưa chạy lại `/tms:review-pr` với bản đã sửa trên 1 PR thật — cần
review + xác nhận nội dung trước khi merge.

## Checklist

- [x] Đổi hành vi/kiến trúc → đã cập nhật `CLAUDE.md` tương ứng (cả 2 phần)
- [ ] Đổi UX cấu hình/bootstrap/cài đặt → N/A, không đổi field `meta.json`
- [ ] Thêm field mới trong `meta.json` → N/A
- [x] Không có `allowed-tools` mới cấp quyền rộng hơn cần thiết
