### PR TITLE
fix(review-pr): stop crashing when ARGUMENTS free text contains a backtick

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,18 @@ finding (data từ diff PR, attacker-controlled) TRƯỚC khi tới `gh api` —
 review khác submit đúng lúc đó thì trỏ nhầm, có thể submit hộ draft PENDING của người khác. `has_submodules`
 cache qua doctor từng khiến PR ĐẦU TIÊN của 1 repo mới (trước khi doctor từng chạy) luôn bị coi
 không có submodule dù PR đó thật sự bump submodule — chuyển qua `Read` thử `.gitmodules` trực tiếp
-mỗi lần, bỏ field cache.
+mỗi lần, bỏ field cache. Block "Ngữ cảnh" từng splice `$ARGUMENTS` thô vào `echo "$ARGUMENTS" | grep
+...` lặp lại 8 lần (Claude Code thay `$ARGUMENTS` bằng đúng text người dùng gõ, KHÔNG escape gì —
+xác nhận qua doc chính thức) — user gõ thêm chỉ dẫn tự do sau URL (Bước 0 cho phép) chứa 1 backtick
+(vd `` `handler` `` trong câu "nên có comment top function `handler`") khiến backtick đó bị hiểu
+thành command-substitution lồng bên trong dấu `"`, lệch cân bằng quote → shell báo lỗi "unmatched
+\"", toàn bộ Ngữ cảnh không fetch được gì. Đã verify root cause + fix bằng sandbox test riêng (Bash,
+không qua Claude Code thật) trước khi sửa. Sửa bằng heredoc delimiter quote (`<<'TMS_ARGS_EOF'`,
+cùng kỹ thuật đã dùng ở Bước 9) — nội dung heredoc là literal tuyệt đối, immune với
+backtick/`"`/`$(...)`. Cú pháp `!`...`` inline CHỈ hỗ trợ 1 dòng (xác nhận qua doc Claude Code
+chính thức: "Slash commands" mục "Inject dynamic context") nên phải đổi qua fenced ` ```! ` block
+(hỗ trợ multi-line) — tiện thể gộp luôn 8 lần extract lặp lại thành ĐÚNG 1 lần (`$URL`/`$OWNER_REPO`/
+`$PULL_NUMBER` là biến bash thật sau đó, không còn splice `$ARGUMENTS` lại lần nào nữa).
 
 **Cấu hình per-repo hỏi 1 lần lúc bootstrap, dùng lại mọi lần review sau của repo đó.** Phần A của
 `setup-flow.md` hỏi user **6 hoặc 7 câu** trong 1 lượt (câu `review_ci_status` chỉ hỏi khi PR đang

--- a/src/commands/review-pr.md
+++ b/src/commands/review-pr.md
@@ -49,22 +49,57 @@ Phần `ARGUMENTS` ngoài URL = chỉ dẫn bổ sung lần này. Chỉ dẫn ng
 
 Canonical URL từ `$ARGUMENTS` (cắt đuôi). Mọi `gh pr view`/`gh pr diff` kèm `-R "owner/repo"` tường minh.
 
-- PR info: !`gh pr view "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1)" -R "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 | sed -E 's#.*github\.com/([^/]+)/([^/]+)/pull/[0-9]+#\1/\2#')" --json number,title,body,author,baseRefName,headRefName 2>/dev/null`
-- Head sha: !`gh pr view "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1)" -R "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 | sed -E 's#.*github\.com/([^/]+)/([^/]+)/pull/[0-9]+#\1/\2#')" --json headRefOid --jq .headRefOid 2>/dev/null`
-- Files: !`gh pr diff "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1)" -R "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 | sed -E 's#.*github\.com/([^/]+)/([^/]+)/pull/[0-9]+#\1/\2#')" --name-only 2>/dev/null`
-- Diff: !`gh pr diff "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1)" -R "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 | sed -E 's#.*github\.com/([^/]+)/([^/]+)/pull/[0-9]+#\1/\2#')" 2>/dev/null`
-- Commits: !`gh pr view "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1)" -R "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 | sed -E 's#.*github\.com/([^/]+)/([^/]+)/pull/[0-9]+#\1/\2#')" --json commits --jq '.commits[].messageHeadline' 2>/dev/null`
-- Comments cũ: !`gh api repos/$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 | sed -E 's#.*github\.com/([^/]+)/([^/]+)/pull/([0-9]+)#\1/\2#')/pulls/$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 | sed -E 's#.*/pull/([0-9]+)#\1#')/comments 2>/dev/null`
-- Size diff theo file (byte, dùng cho Bước 7 guard file to/dump; `--paginate` — PR >30 file thì
-  GitHub trả nhiều trang, thiếu cờ này sẽ mất size của file ở trang sau): !`gh api --paginate repos/$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 | sed -E 's#.*github\.com/([^/]+)/([^/]+)/pull/([0-9]+)#\1/\2#')/pulls/$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 | sed -E 's#.*/pull/([0-9]+)#\1#')/files --jq '.[] | if .patch == null then "UNKNOWN(không có patch — quá lớn/binary/rename) \(.filename)" else "\(.patch|length) \(.filename)" end' 2>/dev/null`
-- CI checks (TOÀN BỘ, không filter — Bước 7 tự lọc `bucket=="fail"` để cảnh báo khi
+**`$ARGUMENTS` là text thô người dùng gõ, Claude Code splice trực tiếp vào lệnh dưới, KHÔNG escape**
+(Bước 0 CHO PHÉP gõ thêm chỉ dẫn tự do sau URL — chỉ dẫn đó có thể chứa `` ` ``/`"`/`$(...)`/xuống
+dòng bất kỳ). Vì vậy khối lệnh dưới đọc `$ARGUMENTS` ĐÚNG 1 LẦN qua heredoc delimiter quote
+(`<<'TMS_ARGS_EOF'`) — nội dung giữa 2 dòng delimiter là literal tuyệt đối, shell KHÔNG parse gì bên
+trong (không backtick, không `$`, không `"`) — rồi chỉ dùng lại `$URL` (chuỗi đã khớp regex, chắc
+chắn sạch vì ký tự hợp lệ trong URL GitHub không có backtick/quote) cho mọi lệnh `gh` bên dưới.
+TUYỆT ĐỐI không đưa `$ARGUMENTS` thô vào bất kỳ lệnh nào khác ngoài khối heredoc này.
+
+```!
+URL="$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' <<'TMS_ARGS_EOF' | head -1
+$ARGUMENTS
+TMS_ARGS_EOF
+)"
+OWNER_REPO="$(echo "$URL" | sed -E 's#.*github\.com/([^/]+)/([^/]+)/pull/[0-9]+#\1/\2#')"
+PULL_NUMBER="$(echo "$URL" | sed -E 's#.*/pull/([0-9]+)#\1#')"
+
+echo "=== PR info ==="
+gh pr view "$URL" -R "$OWNER_REPO" --json number,title,body,author,baseRefName,headRefName 2>/dev/null
+
+echo "=== Head sha ==="
+gh pr view "$URL" -R "$OWNER_REPO" --json headRefOid --jq .headRefOid 2>/dev/null
+
+echo "=== Files ==="
+gh pr diff "$URL" -R "$OWNER_REPO" --name-only 2>/dev/null
+
+echo "=== Diff ==="
+gh pr diff "$URL" -R "$OWNER_REPO" 2>/dev/null
+
+echo "=== Commits ==="
+gh pr view "$URL" -R "$OWNER_REPO" --json commits --jq '.commits[].messageHeadline' 2>/dev/null
+
+echo "=== Comments cũ ==="
+gh api "repos/$OWNER_REPO/pulls/$PULL_NUMBER/comments" 2>/dev/null
+
+echo "=== Size diff theo file ==="
+gh api --paginate "repos/$OWNER_REPO/pulls/$PULL_NUMBER/files" --jq '.[] | if .patch == null then "UNKNOWN(không có patch — quá lớn/binary/rename) \(.filename)" else "\(.patch|length) \(.filename)" end' 2>/dev/null
+
+echo "=== CI checks ==="
+gh pr checks "$URL" -R "$OWNER_REPO" --json bucket,name,link --jq '.[] | "\(.bucket) \(.name) — \(.link)"' 2>/dev/null || true
+```
+
+- **Size diff theo file** (byte, dùng cho Bước 7 guard file to/dump; `--paginate` — PR >30 file thì
+  GitHub trả nhiều trang, thiếu cờ này sẽ mất size của file ở trang sau).
+- **CI checks** (TOÀN BỘ, không filter — Bước 7 tự lọc `bucket=="fail"` để cảnh báo khi
   `review_ci_status` != `false`; setup-flow Phần A dùng chính mảng này để quyết định CÓ hỏi câu
   `review_ci_status` lúc bootstrap hay không — rỗng nghĩa là repo/PR này không có CI check nào, hỏi
   sẽ vô nghĩa. Fetch luôn vô hại nếu repo không có CI — `|| true` để không exit lỗi khi `gh pr
-  checks` báo check fail/pending): !`gh pr checks "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1)" -R "$(echo "$ARGUMENTS" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 | sed -E 's#.*github\.com/([^/]+)/([^/]+)/pull/[0-9]+#\1/\2#')" --json bucket,name,link --jq '.[] | "\(.bucket) \(.name) — \(.link)"' 2>/dev/null || true`
+  checks` báo check fail/pending).
 
-**Repo name** (thư mục memory) = segment `<repo>` từ PR URL — không suy từ pwd/remote. Hai owner
-trùng tên repo dùng chung 1 thư mục (giới hạn đã biết).
+**Repo name** (thư mục memory) = segment `<repo>` từ PR URL (`$OWNER_REPO` ở trên) — không suy từ
+pwd/remote. Hai owner trùng tên repo dùng chung 1 thư mục (giới hạn đã biết).
 
 **Filesystem:** thao tác tại đúng pwd phiên. Cấm `cd` / tự dò git root (ngoại lệ: subshell worktree
 Bước 1). Trước khi ghi `notebooks/review/...`, nêu pwd + repo name trong chat.


### PR DESCRIPTION
## Mô tả

User tái hiện được lỗi: gõ `/tms:review-pr <URL> + chỉ dẫn tự do` (Bước 0 cho phép), chỉ dẫn có 1
backtick (vd `` `handler` `` trong câu "nên có comment top function `handler`") → block "Ngữ cảnh"
crash với `unmatched "`, không fetch được gì.

**Nguyên nhân** (đã verify bằng sandbox test, không đoán): `$ARGUMENTS` được Claude Code splice
**thô, không escape** vào lệnh (xác nhận qua doc chính thức Claude Code) — lệnh `echo "$ARGUMENTS" |
grep ...` lặp 8 lần trong "Ngữ cảnh". Backtick trong text tự do bị bash hiểu thành
command-substitution lồng trong dấu `"`, lệch quote → crash.

## Loại thay đổi

- [x] 🐛 Fix bug
- [ ] 🔴 Breaking change
- [ ] ✨ Feature mới
- [ ] 📝 Docs
- [ ] 🔧 Chore

## Thay đổi chính

- Đọc `$ARGUMENTS` ĐÚNG 1 LẦN qua heredoc quote-delimiter (`<<'TMS_ARGS_EOF'`) — literal tuyệt đối,
  immune với backtick/`"`/`$(...)` (đã test cả payload `$(rm -rf ...)` thật — không bị thực thi).
- Dùng lại biến bash (`$URL`/`$OWNER_REPO`/`$PULL_NUMBER`) cho toàn bộ 8 lệnh `gh`, thay vì splice
  lại `$ARGUMENTS` 8 lần — gộp luôn phần lặp thừa.
- Đổi từ `!`...`` inline (chỉ hỗ trợ 1 dòng, xác nhận qua doc Claude Code) sang fenced ` ```! ` block
  (hỗ trợ multi-line, bắt buộc để dùng heredoc).
- Cập nhật `CLAUDE.md` mục "Lý do bug đã gặp".

## Đã test thế nào

Sandbox test riêng (Bash, không qua Claude Code thật) trước khi sửa file, verify đúng root cause
(reproduce y hệt class lỗi `unmatched "`). Sau khi sửa, test lại 3 case bằng bash trực tiếp:
- Input sạch, chỉ URL → extract đúng.
- Input crash gốc (backtick + `$(rm -rf ...)` + quote lẫn) → không crash, không injection, extract
  đúng URL đầu tiên.
- ARGUMENTS rỗng → không crash, trả rỗng (Bước 0 đã có gate riêng).

Chưa chạy `/tms:review-pr` thật với bản đã sửa — cần review + xác nhận trước khi merge.

## Checklist

- [x] Đổi hành vi/kiến trúc → đã cập nhật `CLAUDE.md`
- [ ] Đổi UX cấu hình/bootstrap/cài đặt → N/A
- [ ] Thêm field mới trong `meta.json` → N/A
- [x] Không có `allowed-tools` mới cấp quyền rộng hơn cần thiết (Ngữ cảnh không qua allowed-tools)