### PR TITLE
feat(review-pr): prefer structured choice UI over free-text for user prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,15 @@ khi USER thật nhập vào input, không áp dụng cho prompt agent tự sinh)
 subagent theo đúng rule thật là được yêu cầu đọc thẳng file, không dựa vào bản tóm tắt của agent
 giao việc (dễ lệch format/rule khi post lên PR thật).
 
+**Mọi câu hỏi có lựa chọn rõ cho user (bootstrap, chiến lược review nhiều file, xác nhận lesson,
+xác nhận submodule PR lệch...) ưu tiên dùng tính năng hỏi-đáp dạng lựa chọn có sẵn của agent (vd
+`AskUserQuestion` ở Claude Code) khi có, thay vì hỏi mở bằng văn tự do.** Phát hiện từ dogfood: user
+test bootstrap phải tự gõ câu trả lời bằng tay dù các lựa chọn đã rõ (vi/en/ja, true/false...) —
+UX kém hơn hẳn so với chọn + Enter mà tính năng đó cho phép, và Cursor/agent khác cũng có tính năng
+tương đương. Rule đặt ở CRITICAL block `review-pr.md` (áp dụng luôn cho mọi case file được `Read`
+vào cùng phiên) + `fix-comment.md` (case file riêng của lệnh đó) — không lặp lại ở từng case file
+lẻ, vì agent đã thấy rule này trong CRITICAL block trước khi đọc tới bất kỳ case nào.
+
 **Phân loại nội dung runtime (I/C/D/K):** Inline = invariant + xương quy trình; Case = hard gate;
 Delete khỏi runtime = lý do bug/lịch sử (chỉ file này); Keep skeleton = khung rút gọn. Mục tiêu:
 cắt chú thích thừa trên hot path, giữ chất lượng post/API.

--- a/src/commands/review-pr.md
+++ b/src/commands/review-pr.md
@@ -27,6 +27,11 @@ description: Review 1 hoặc nhiều PR GitHub đa stack (tuần tự), học co
 > **Giao việc review cho 1 subagent (Agent tool) — bất kỳ lúc nào, không riêng multi-PR (xem Bước
 > 0)** — subagent PHẢI được yêu cầu `Read` NGUYÊN VĂN file lệnh này rồi làm theo, KHÔNG paraphrase
 > rule qua prompt tay.
+> **Mọi câu hỏi có lựa chọn rõ cho user (không phải hỏi mở tự do) — DÙNG tính năng hỏi-đáp dạng lựa
+> chọn có sẵn của agent (vd `AskUserQuestion` ở Claude Code) nếu có, để user chọn + Enter thay vì
+> phải gõ tự do.** Không có tính năng đó thì hỏi tự nhiên qua chat như bình thường. Áp dụng cho MỌI
+> câu hỏi lựa chọn trong file này và mọi case file liên quan (bootstrap, chiến lược review nhiều
+> file/file to, xác nhận lesson, xác nhận submodule PR lệch...).
 
 
 ## Bước 0 — Validate ARGUMENTS

--- a/src/setup-flow.md
+++ b/src/setup-flow.md
@@ -41,8 +41,9 @@ qua context — tốn token); `mkdir -p` để tạo thư mục.
    `cp "${CLAUDE_PLUGIN_ROOT}/ALWAYS_RULE.md" "notebooks/review/<repo>/ALWAYS_RULE.md"`. Từ
    đây về sau `review-pr.md` (Bước 5) đọc BẢN LOCAL này — team có thể mở/chỉnh sửa ngay trong repo của họ
    theo dự án, không cần vào tận plugin. Bản trong plugin chỉ là "seed" mặc định lúc bootstrap.
-6. Hỏi user **6 hoặc 7 câu trong 1 lượt** (tuỳ có CI hay không — xem câu 5), ngay trong chat (câu
-   hỏi tự nhiên là đủ, không bắt buộc tool cụ thể): (1) ngôn ngữ output — vi/en/ja; (2)
+6. Hỏi user **6 hoặc 7 câu trong 1 lượt** (tuỳ có CI hay không — xem câu 5) — dùng tính năng hỏi-đáp
+   dạng lựa chọn có sẵn của agent nếu có (xem CRITICAL `review-pr.md`), mỗi câu kèm sẵn lựa chọn
+   default; không có tính năng đó thì hỏi tự nhiên qua chat: (1) ngôn ngữ output — vi/en/ja; (2)
    `auto_submit_review` true/false (mặc định **false**); (3) `auto_resolve_fixed_findings`
    true/false (mặc định **false**); (4) `doctor_schedule` — chu kỳ doctor lại convention (`{N} days`
    | `{N} weeks` | `{N} months` | `never`; mặc định **`1 months`** nếu user không chọn); (5)


### PR DESCRIPTION
## Mô tả

Test dogfood setup-flow bootstrap: agent hỏi đúng nội dung nhưng bằng chat text thường, user phải
tự gõ đáp án dù mọi câu hỏi đều có sẵn 1 tập lựa chọn cố định (vi/en/ja, true/false, 3 chiến lược
đặt tên...) — trải nghiệm kém hơn hẳn tính năng chọn + Enter mà Claude Code (`AskUserQuestion`) và
các agent khác (Cursor...) đều đã hỗ trợ.

**Phụ thuộc PR #12** (base trực tiếp lên đó).

## Loại thay đổi

- [x] ✨ Feature mới (UX)
- [ ] 🔴 Breaking change
- [ ] 🐛 Fix bug
- [ ] 📝 Docs
- [ ] 🔧 Chore

## Thay đổi chính

Thêm rule vào CRITICAL block `review-pr.md`: mọi câu hỏi có lựa chọn rõ cho user (bootstrap, chiến
lược review nhiều file, xác nhận lesson, xác nhận submodule PR lệch...) ưu tiên dùng tính năng
hỏi-đáp dạng lựa chọn có sẵn của agent nếu có, fallback hỏi tự nhiên qua chat khi không có. Đặt 1
lần ở CRITICAL block (áp dụng luôn cho mọi case file được `Read` vào cùng phiên), không lặp lại ở
từng case file lẻ — cùng pattern đã dùng cho rule subagent. Xoá luôn câu "không bắt buộc tool cụ
thể" cũ ở `setup-flow.md` (mâu thuẫn trực tiếp với rule mới).

Rule tương tự đã thêm vào `fix-comment.md` (branch riêng, PR #8) ở 1 commit theo sau.

## Đã test thế nào

Phát hiện qua chính live-test thật của user trên branch tổng hợp — đây là fix theo feedback trực
tiếp, không phải suy đoán.

## Checklist

- [x] Đổi hành vi/kiến trúc → đã cập nhật CLAUDE.md
- [ ] Đổi UX cấu hình/bootstrap/cài đặt → N/A (không đổi field, chỉ đổi CÁCH hỏi)
- [ ] Thêm field mới trong meta.json → N/A
- [x] Không có allowed-tools mới