### PR TITLE
fix(review-pr): batch bootstrap questions within structured-QA per-call limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,13 @@ tương đương. Rule đặt ở CRITICAL block `review-pr.md` (áp dụng luô
 vào cùng phiên) + `fix-comment.md` (case file riêng của lệnh đó) — không lặp lại ở từng case file
 lẻ, vì agent đã thấy rule này trong CRITICAL block trước khi đọc tới bất kỳ case nào.
 
+**2 bổ sung sau khi user test thật:** (1) tính năng hỏi-đáp này thường giới hạn số CÂU HỎI ĐỘC LẬP
+mỗi lượt gọi (`AskUserQuestion` ở Claude Code tối đa 4) — bootstrap có 6-7 câu nên PHẢI chia 2 lượt
+gọi liên tiếp (câu 1-4 rồi câu 5-7), không nhồi hết 1 lượt rồi bị cắt/lỗi. (2) Mỗi câu hỏi nên đánh
+dấu 1 lựa chọn làm recommend khi có cơ sở hợp lý (khớp giá trị default đã định nghĩa, hoặc phán đoán
+thường gặp nhất) — nhưng KHÔNG ép ra recommend gượng gạo khi các lựa chọn thật sự ngang nhau tuỳ
+hoàn cảnh (vd 2 chiến lược review đều hợp lý tuỳ PR, không có cái nào mặc định tốt hơn).
+
 **Phân loại nội dung runtime (I/C/D/K):** Inline = invariant + xương quy trình; Case = hard gate;
 Delete khỏi runtime = lý do bug/lịch sử (chỉ file này); Keep skeleton = khung rút gọn. Mục tiêu:
 cắt chú thích thừa trên hot path, giữ chất lượng post/API.

--- a/src/commands/review-pr.md
+++ b/src/commands/review-pr.md
@@ -31,7 +31,12 @@ description: Review 1 hoặc nhiều PR GitHub đa stack (tuần tự), học co
 > chọn có sẵn của agent (vd `AskUserQuestion` ở Claude Code) nếu có, để user chọn + Enter thay vì
 > phải gõ tự do.** Không có tính năng đó thì hỏi tự nhiên qua chat như bình thường. Áp dụng cho MỌI
 > câu hỏi lựa chọn trong file này và mọi case file liên quan (bootstrap, chiến lược review nhiều
-> file/file to, xác nhận lesson, xác nhận submodule PR lệch...).
+> file/file to, xác nhận lesson, xác nhận submodule PR lệch...). Tính năng đó thường giới hạn số
+> câu HỎI ĐỘC LẬP trong 1 lượt gọi (vd `AskUserQuestion` ở Claude Code tối đa 4) — cần hỏi nhiều
+> câu hơn giới hạn đó → chia thành nhiều lượt gọi LIÊN TIẾP (hết lượt này mới gọi lượt sau), KHÔNG
+> nhồi hết vào 1 lượt. Có 1 lựa chọn nào hợp lý làm mặc định (default trong file này, hoặc phán
+> đoán thường gặp nhất) → đánh dấu recommend đúng lựa chọn đó; KHÔNG có lựa chọn nào thật sự hợp lý
+> hơn hẳn (2 phương án ngang nhau tuỳ hoàn cảnh) → để trống, KHÔNG ép ra 1 recommend gượng gạo.
 
 
 ## Bước 0 — Validate ARGUMENTS

--- a/src/setup-flow.md
+++ b/src/setup-flow.md
@@ -41,9 +41,11 @@ qua context — tốn token); `mkdir -p` để tạo thư mục.
    `cp "${CLAUDE_PLUGIN_ROOT}/ALWAYS_RULE.md" "notebooks/review/<repo>/ALWAYS_RULE.md"`. Từ
    đây về sau `review-pr.md` (Bước 5) đọc BẢN LOCAL này — team có thể mở/chỉnh sửa ngay trong repo của họ
    theo dự án, không cần vào tận plugin. Bản trong plugin chỉ là "seed" mặc định lúc bootstrap.
-6. Hỏi user **6 hoặc 7 câu trong 1 lượt** (tuỳ có CI hay không — xem câu 5) — dùng tính năng hỏi-đáp
-   dạng lựa chọn có sẵn của agent nếu có (xem CRITICAL `review-pr.md`), mỗi câu kèm sẵn lựa chọn
-   default; không có tính năng đó thì hỏi tự nhiên qua chat: (1) ngôn ngữ output — vi/en/ja; (2)
+6. Hỏi user **6 hoặc 7 câu trong 1 lượt bootstrap** (tuỳ có CI hay không — xem câu 5) — dùng tính
+   năng hỏi-đáp dạng lựa chọn có sẵn của agent nếu có (xem CRITICAL `review-pr.md`), mỗi câu kèm
+   sẵn lựa chọn recommend đúng giá trị default ghi dưới đây; tính năng đó giới hạn số câu/lượt gọi
+   (vd tối đa 4) → chia 2 lượt gọi liên tiếp (câu 1-4 rồi câu 5-7, hết lượt trước mới gọi lượt sau).
+   Không có tính năng đó thì hỏi tự nhiên qua chat: (1) ngôn ngữ output — vi/en/ja; (2)
    `auto_submit_review` true/false (mặc định **false**); (3) `auto_resolve_fixed_findings`
    true/false (mặc định **false**); (4) `doctor_schedule` — chu kỳ doctor lại convention (`{N} days`
    | `{N} weeks` | `{N} months` | `never`; mặc định **`1 months`** nếu user không chọn); (5)


### PR DESCRIPTION
## Mô tả

Feedback tiếp theo từ user: các hardness editor/CLI (Claude Code, và có thể agent khác) giới hạn số
câu hỏi độc lập mỗi lượt gọi tính năng hỏi-đáp dạng lựa chọn (`AskUserQuestion` ở Claude Code tối đa
4). Bootstrap có 6-7 câu — vượt giới hạn này nếu nhồi hết 1 lượt.

**Phụ thuộc PR #14** (base trực tiếp lên đó).

## Loại thay đổi

- [x] 🐛 Fix bug (UX)
- [ ] 🔴 Breaking change
- [ ] ✨ Feature mới
- [ ] 📝 Docs
- [ ] 🔧 Chore

## Thay đổi chính

- CRITICAL block: thêm rule chia nhiều lượt gọi liên tiếp khi vượt giới hạn câu/lượt của tính năng
  hỏi-đáp, không nhồi hết vào 1 lượt.
- `setup-flow.md`: chốt cụ thể cách chia bootstrap — lượt 1 câu 1-4, lượt 2 câu 5-7.
- Thêm luôn: chỉ đánh dấu recommend khi có cơ sở hợp lý (khớp default đã định nghĩa hoặc case phổ
  biến hơn) — không ép recommend khi các lựa chọn ngang nhau tuỳ hoàn cảnh.

## Đã test thế nào

Feedback trực tiếp từ user, không phải suy đoán.

## Checklist

- [x] Đổi hành vi/kiến trúc → đã cập nhật CLAUDE.md
- [ ] Đổi UX cấu hình/bootstrap/cài đặt → N/A (không đổi field, chỉ đổi cách hỏi)
- [ ] Thêm field mới trong meta.json → N/A
- [x] Không có allowed-tools mới