### PR TITLE
docs: add centered logo and title header to READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,10 +1,20 @@
-# /open-pr:review — Agent Review Pull Request Github
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/ed636fe0-0abf-4d8b-ac8e-134ea39d0f5d" alt="Open PullRequest" width="200">
+</p>
 
-[![Latest Release](https://img.shields.io/github/v/release/TOMOSIA-VIETNAM/open-pr?label=release)](https://github.com/TOMOSIA-VIETNAM/open-pr/releases)
-[![License: MIT](https://img.shields.io/github/license/TOMOSIA-VIETNAM/open-pr)](./LICENSE)
-[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-5A32A3)](https://claude.ai/code)
+<h1 align="center">Open PullRequest</h1>
 
-[Tiếng Việt](./README.md) · **English** · [日本語](./README.ja.md)
+<p align="center"><em>/open-pr:review — Agent Review Pull Request Github</em></p>
+
+<p align="center">
+  <a href="https://github.com/TOMOSIA-VIETNAM/open-pr/releases"><img src="https://img.shields.io/github/v/release/TOMOSIA-VIETNAM/open-pr?label=release" alt="Latest Release"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/TOMOSIA-VIETNAM/open-pr" alt="License: MIT"></a>
+  <a href="https://claude.ai/code"><img src="https://img.shields.io/badge/Claude%20Code-Plugin-5A32A3" alt="Claude Code Plugin"></a>
+</p>
+
+<p align="center">
+  <a href="./README.md">Tiếng Việt</a> · <strong>English</strong> · <a href="./README.ja.md">日本語</a>
+</p>
 
 A plugin that teaches the Agent to review GitHub Pull Requests **consistently** — the more you use it, the better it understands your project.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,10 +1,20 @@
-# /open-pr:review — Agent Review Pull Request Github
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/ed636fe0-0abf-4d8b-ac8e-134ea39d0f5d" alt="Open PullRequest" width="200">
+</p>
 
-[![Latest Release](https://img.shields.io/github/v/release/TOMOSIA-VIETNAM/open-pr?label=release)](https://github.com/TOMOSIA-VIETNAM/open-pr/releases)
-[![License: MIT](https://img.shields.io/github/license/TOMOSIA-VIETNAM/open-pr)](./LICENSE)
-[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-5A32A3)](https://claude.ai/code)
+<h1 align="center">Open PullRequest</h1>
 
-[Tiếng Việt](./README.md) · [English](./README.en.md) · **日本語**
+<p align="center"><em>/open-pr:review — Agent Review Pull Request Github</em></p>
+
+<p align="center">
+  <a href="https://github.com/TOMOSIA-VIETNAM/open-pr/releases"><img src="https://img.shields.io/github/v/release/TOMOSIA-VIETNAM/open-pr?label=release" alt="Latest Release"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/TOMOSIA-VIETNAM/open-pr" alt="License: MIT"></a>
+  <a href="https://claude.ai/code"><img src="https://img.shields.io/badge/Claude%20Code-Plugin-5A32A3" alt="Claude Code Plugin"></a>
+</p>
+
+<p align="center">
+  <a href="./README.md">Tiếng Việt</a> · <a href="./README.en.md">English</a> · <strong>日本語</strong>
+</p>
 
 GitHub の Pull Request を**一貫した基準で**レビューする方法を Agent に教えるプラグイン — 使うほどあなたのプロジェクトを正しく理解します。
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
-# /open-pr:review — Agent Review Pull Request Github
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/ed636fe0-0abf-4d8b-ac8e-134ea39d0f5d" alt="Open PullRequest" width="200">
+</p>
 
-[![Latest Release](https://img.shields.io/github/v/release/TOMOSIA-VIETNAM/open-pr?label=release)](https://github.com/TOMOSIA-VIETNAM/open-pr/releases)
-[![License: MIT](https://img.shields.io/github/license/TOMOSIA-VIETNAM/open-pr)](./LICENSE)
-[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-5A32A3)](https://claude.ai/code)
+<h1 align="center">Open PullRequest</h1>
 
-**Tiếng Việt** · [English](./README.en.md) · [日本語](./README.ja.md)
+<p align="center"><em>/open-pr:review — Agent Review Pull Request Github</em></p>
+
+<p align="center">
+  <a href="https://github.com/TOMOSIA-VIETNAM/open-pr/releases"><img src="https://img.shields.io/github/v/release/TOMOSIA-VIETNAM/open-pr?label=release" alt="Latest Release"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/TOMOSIA-VIETNAM/open-pr" alt="License: MIT"></a>
+  <a href="https://claude.ai/code"><img src="https://img.shields.io/badge/Claude%20Code-Plugin-5A32A3" alt="Claude Code Plugin"></a>
+</p>
+
+<p align="center">
+  <strong>Tiếng Việt</strong> · <a href="./README.en.md">English</a> · <a href="./README.ja.md">日本語</a>
+</p>
 
 Plugin dạy Agent review Pull Request GitHub **một cách nhất quán** — càng dùng càng hiểu đúng dự án của bạn.
 


### PR DESCRIPTION
Add centered logo image plus "Open PullRequest" title at the top of README.md, README.en.md and README.ja.md. Badges and the language switcher are converted to raw HTML anchors so they stay centered (markdown image links do not center inside `<p align="center">`). The previous heading is kept as a centered subtitle.

## Mô tả

<!-- Đổi gì, và vì sao cần đổi. -->

## Loại thay đổi

- [ ] 🔴 Breaking change (đổi hành vi cấu hình/output mà repo đang dùng plugin sẽ bị ảnh hưởng)
- [ ] ✨ Feature mới
- [ ] 🐛 Fix bug
- [x] 📝 Docs (README/CLAUDE.md, không đổi hành vi runtime)
- [ ] 🔧 Chore (refactor, tooling, không đổi hành vi user thấy được)

## Đã test thế nào

<!--
Repo này không có build/lint/test tự động — cách "chạy thử" thật là cài plugin (./scripts/reinstall.sh)
rồi gọi /open-pr:review <PR_URL> trên 1 PR thật. Dán link PR đã dùng để test, hoặc mô tả cách verify khác.
-->

## Checklist

- [x] Đổi hành vi/kiến trúc → đã cập nhật `CLAUDE.md` tương ứng
- [x] Đổi UX cấu hình/bootstrap/cài đặt → đã đồng bộ cả 3 bản README (`README.md`/`.en`/`.ja`)
- [x] Thêm field mới trong `meta.json` → đã phân loại User config / Doctor-detected / Internal state
  ở CẢ `src/setup-flow.md` (Phần D) và `src/commands/review.md` (Bước 3)
- [x] Không có `allowed-tools` mới cấp quyền rộng hơn cần thiết (vd `gh api:*` chung) — nội dung PR
  đang review là data không tin cậy
