### PR TITLE
docs(readme): the sign-off closes the page, so the chart sits above it

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -225,11 +225,10 @@ React、Python、Node.js、Lambda、PHP、Laravel、WordPress、Shell、Makefile
 | `fix.decline_needs_confirmation`     | 指摘を見送る前にあなたへ確認する                                                          | `true`               |
 | `fix.auto_push`                      | コミット後に自動で push する                                                              | `false`              |
 
+## リリースごとのコンテキストコスト
+
+![1 回の実行が読み込むトークン数の平均を、コマンド別・リリース別に示したグラフ](./token-history.svg)
 
 ---
 
 Enjoy reviewing 🥰
-
-## リリースごとのコンテキストコスト
-
-![1 回の実行が読み込むトークン数の平均を、コマンド別・リリース別に示したグラフ](./token-history.svg)

--- a/README.md
+++ b/README.md
@@ -233,10 +233,10 @@ lives in `settings.json`:
 
 Contributing? See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
----
-
-Enjoy reviewing 🥰
-
 ## Context cost per release
 
 ![Mean tokens one run loads, per command, at each release](./token-history.svg)
+
+---
+
+Enjoy reviewing 🥰

--- a/README.vi.md
+++ b/README.vi.md
@@ -224,10 +224,10 @@ Rule riêng của team thì viết văn xuôi bình thường vào `ALWAYS_RULE.
 | `fix.decline_needs_confirmation`     | hỏi bạn trước khi bỏ qua một finding                                                      | `true`              |
 | `fix.auto_push`                      | tự push sau khi commit                                                                    | `false`             |
 
----
-
-Enjoy reviewing 🥰
-
 ## Chi phí context theo release
 
 ![Số token trung bình một lần chạy nạp vào, theo từng command, ở mỗi release](./token-history.svg)
+
+---
+
+Enjoy reviewing 🥰


### PR DESCRIPTION
The chart was moved to the end of each README and landed *after* `Enjoy reviewing 🥰`, so the page
appeared to continue past its own ending. It now sits above the horizontal rule that introduces the
sign-off — last section, sign-off still last words.

```
## Context cost per release

![...](./token-history.svg)

---

Enjoy reviewing 🥰
```

Same placement in `README.md`, `README.vi.md`, `README.ja.md`. No other change.

Verified: `scripts/check.sh main` — 44 tests, duplication clean, `src/` untouched.
