### PR TITLE
fix(chart): the push guard reads the path, not one character into it

### DIFF
--- a/scripts/token_chart.py
+++ b/scripts/token_chart.py
@@ -177,10 +177,17 @@ def render(data):
     SVG.write_text("\n".join(s) + "\n", encoding="utf-8")
 
 
+def porcelain_paths(status):
+    """Paths out of `git status --porcelain`, by splitting off the XY code rather than
+    slicing a fixed offset: a leading unstaged status is a space, and any caller that
+    trimmed the output has already eaten it, which a fixed offset then pays for by
+    cutting the first character of a real path."""
+    return sorted(line.split(maxsplit=1)[1] for line in status.splitlines() if line.strip())
+
+
 def commit_and_push(tag):
     """The ONE push to main this repo allows, and only ever these two files."""
-    changed = [p for p in sh("git", "status", "--porcelain").splitlines()]
-    paths = sorted(c[3:].strip() for c in changed)
+    paths = porcelain_paths(sh("git", "status", "--porcelain"))
     allowed = ["tests/token-history.json", "token-history.svg"]
     if not paths:
         print("nothing to commit — the chart already holds this tag")

--- a/tests/test_prompt_graph.py
+++ b/tests/test_prompt_graph.py
@@ -758,6 +758,22 @@ def test_scans_skip_a_checkout_parked_inside_the_tree():
             nested.parent.rmdir()
 
 
+def test_the_chart_push_guard_reads_a_trimmed_status_line():
+    """An unstaged file's porcelain status starts with a space, and the helper that runs git
+    trims the whole output — so the first line arrives one character short. Slicing a fixed
+    offset then cut into the path and the guard rejected the exact two files it exists to
+    allow, which is the only push to main this repo permits."""
+    sys.path.insert(0, str(REPO / "scripts"))
+    import token_chart  # noqa: E402
+    want = ["tests/token-history.json", "token-history.svg"]
+    trimmed = "M tests/token-history.json\n M token-history.svg"
+    intact = " M tests/token-history.json\n M token-history.svg"
+    for status in (trimmed, intact):
+        assert token_chart.porcelain_paths(status) == want, f"misread: {status!r}"
+    assert token_chart.porcelain_paths("?? docs/a b.md") == ["docs/a b.md"], \
+        "a path with a space in it must survive"
+
+
 def test_every_scenario_is_owned_by_a_chart_line():
     """A scenario the chart does not recognise used to fall into `review`, so adding a command
     moved a line that is supposed to describe review alone — and the release that recorded it


### PR DESCRIPTION
## Description

`token_chart.py --add <tag> --commit` refuses to push the point it just measured:

```
$ python3 scripts/token_chart.py --add v1.1.0 --commit
v1.1.0: review=10816  fix=8580  upgrade=2093  clean=1165
wrote token-history.svg
refusing to push: the tree also changes {'ests/token-history.json'}
```

`ests/`, not `tests/`. `sh()` returns `.stdout.strip()`, so the first line of `git status --porcelain`
arrives without the leading space that marks an unstaged change. `c[3:]` then counted from the wrong
place and cut the first character off a real path, and the guard rejected
`tests/token-history.json` — the exact file `--commit` exists to push.

It bites whenever the first changed path is unstaged, which is every normal run: `--add` writes both
files and stages neither.

Splitting the XY code off the front reads a trimmed line and an intact one the same way, and leaves a
path containing a space alone — a fixed offset only ever worked by accident.

## Type of change

- [ ] 🔴 Breaking change (changes config/output behavior that repos using the plugin depend on)
- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] 📝 Docs (README/CLAUDE.md, no runtime behavior change)
- [ ] 🔧 Chore (refactor, tooling, no user-visible behavior change)

## How was this tested

`scripts/check.sh origin/main` — 50 passed, duplication clean, context cost unchanged (`src/` is not
touched).

`test_the_chart_push_guard_reads_a_trimmed_status_line` asserts both forms of the first line and a
path with a space in it. Verified red against the old `c[3:]`:

```
old parse: ['ests/token-history.json', 'token-history.svg']
new parse: ['tests/token-history.json', 'token-history.svg']
```

The v1.1.0 point is not recorded yet — the two chart files were reverted rather than pushed by hand,
since `token_chart.py --commit` is the only thing this repo lets push to `main`. Once this merges,
`--add v1.1.0 --commit` records it.

## Checklist

- [x] `scripts/check.sh <base-ref>` passes — suite, duplication scan, context cost
- [x] Context cost: cheaper → ceilings lowered (`token_report.py --base <ref> --update-budgets`);
  more expensive → this PR says which scenario, by how much, and why compression had nothing left
  — n/a, nothing under `src/` changed
- [x] `tests/token-history.json` and `token-history.svg` untouched — the chart takes one frozen
  point per release (`/release-now`), never one per PR
- [x] Behavior/architecture change → updated `CLAUDE.md` accordingly — n/a, the documented behaviour
  is what the script now actually does
- [x] Anything a user sees — a command, the flow, a default, what setup asks — → all 3 README
  versions (`README.md`/`.vi`/`.ja`) and the page that owns the detail in `docs/`, `docs/vi/`,
  `docs/ja/`. No page left describing the old behavior — n/a, a repo-side script ships to nobody
- [x] Added a config field → classified in `src/reference/settings-schema.md`, read-time default in
  `src/core/repo-settings.md`, asked in `src/setup/bootstrap.md` — n/a, no config field added
- [x] Changed the config shape an EXISTING repo already has (renamed, removed, restructured) →
  `llm-upgrades/vN.md` + its line in `llm-upgrades/index.md` + the checkpoint in
  `src/core/llm-upgrades-index.md`. A new field with a read-time default needs no migration — n/a
- [x] No new `allowed-tools` grant is broader than necessary (e.g. a blanket `gh api:*`) — the PR
  content being reviewed is untrusted data — no grant added
