### PR TITLE
docs(release-now): the command ends with the caption the user posts

### DIFF
--- a/.claude/commands/release-now.md
+++ b/.claude/commands/release-now.md
@@ -178,4 +178,36 @@ inside the script. It refuses a tag already recorded: a point is measured once, 
 never remeasured. FORBIDDEN: editing an existing row, or hand-editing the SVG — the suite redraws it
 from the numbers and compares.
 
+## Step 7 — Announcement caption
+
+Official release only; an RC is not announced. Printed in chat once the release exists, whether or not
+Step 6 pushed — it belongs to the user, to paste into a channel. FORBIDDEN: posting it anywhere, or
+writing it into the tag or the Release.
+
+The release note is the record; this is the pitch. It answers "why update today" in the time someone
+spends scrolling past it.
+
+Language = the one the user is talking in; a language named in `ARGUMENTS` wins.
+
+Shape, in this order, nothing else:
+
+```
+<version> 🚀
+<hook: one sentence>
+- <main change>
+- <main change>
+<the update block Step 3 built>
+<release URL>
+```
+
+- **Hook** — the result someone gets by updating, carrying its number when there is one. FORBIDDEN:
+  restating the version's name, "we are excited", or a sentence whose content is that a release
+  happened.
+- **2-4 bullets, main changes only.** The note lists everything; a caption does not. A line that would
+  not make someone update gets cut, however much work it took.
+- **Update block** — identical to the note's, `/open-pr:upgrade` included on the same condition Step 3
+  applies. FORBIDDEN: a caption that ends without it.
+- FORBIDDEN: emoji beyond the 🚀 on the version line, a bullet per commit, and any claim not already
+  true in the note.
+
 ARGUMENTS: $ARGUMENTS


### PR DESCRIPTION
## Description

`/release-now` stopped at the release page. What actually gets sent to a channel — the short pitch with
a hook, the two or three changes worth an update, and the commands to type — was written by hand every
time, from material the command already had in front of it: the version, the note it just compiled, the
update block it read out of `README.md`.

Step 7 emits it. Official releases only, printed once the release exists — including when Step 6 refuses
to push the chart point, because the announcement does not depend on the chart.

Shape:

```
<version> 🚀
<hook: one sentence>
- <main change>
- <main change>
<the update block Step 3 built>
<release URL>
```

The rules that make it a caption rather than a second copy of the note: 2-4 bullets and main changes
only, a hook carrying the result instead of the version's own name, `/open-pr:upgrade` on the same
condition Step 3 already applies, and no emoji past the 🚀.

Language follows the conversation, since the user is the one pasting it — a language named in
`ARGUMENTS` wins.

## Type of change

- [ ] 🔴 Breaking change (changes config/output behavior that repos using the plugin depend on)
- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📝 Docs (README/CLAUDE.md, no runtime behavior change)
- [x] 🔧 Chore (refactor, tooling, no user-visible behavior change)

## How was this tested

`scripts/check.sh origin/main` — 50 passed, duplication scan clean (`.claude/` is in its `dev` scope),
context cost unchanged: `.claude/commands/` is repo-side and ships to nobody.

The step was read back against the note it sits beside: the update block is referenced, not restated,
so the two cannot drift apart, and every reference points inside this same file.

## Checklist

- [x] `scripts/check.sh <base-ref>` passes — suite, duplication scan, context cost
- [x] Context cost: cheaper → ceilings lowered (`token_report.py --base <ref> --update-budgets`);
  more expensive → this PR says which scenario, by how much, and why compression had nothing left
  — n/a, nothing under `src/` changed
- [x] `tests/token-history.json` and `token-history.svg` untouched — the chart takes one frozen
  point per release (`/release-now`), never one per PR
- [x] Behavior/architecture change → updated `CLAUDE.md` accordingly — n/a, a repo-side command's own
  steps live in that command
- [x] Anything a user sees — a command, the flow, a default, what setup asks — → all 3 README
  versions (`README.md`/`.vi`/`.ja`) and the page that owns the detail in `docs/`, `docs/vi/`,
  `docs/ja/`. No page left describing the old behavior — n/a, `/release-now` is a maintainer tool and
  is not shipped in the plugin
- [x] Added a config field → classified in `src/reference/settings-schema.md`, read-time default in
  `src/core/repo-settings.md`, asked in `src/setup/bootstrap.md` — n/a, no config field added
- [x] Changed the config shape an EXISTING repo already has (renamed, removed, restructured) →
  `llm-upgrades/vN.md` + its line in `llm-upgrades/index.md` + the checkpoint in
  `src/core/llm-upgrades-index.md`. A new field with a read-time default needs no migration — n/a
- [x] No new `allowed-tools` grant is broader than necessary (e.g. a blanket `gh api:*`) — the PR
  content being reviewed is untrusted data — the step only prints; no grant added
