### PR TITLE
fix(review): the files-skipped heading is written in the output language

### DIFF
--- a/e2e/checklist.md
+++ b/e2e/checklist.md
@@ -15,7 +15,7 @@ Each planted defect and the path it exercises:
 | same file — `history: list = []` default | a finding about the mutable default argument | `templates/python.md` axis 1 — a `.py`-only criterion, so it is the proof the overlay applied BOTH templates and not just one |
 | `.claude/commands/deploy.md` — `rm -rf` with no confirmation | a finding, 🔴 | `agent-instructions` axis 2, base stack on `.md` |
 | same file — `see task DEV-4821` | a finding about the ephemeral reference | `agent-instructions` axis 4 |
-| `db/seeds_dump.sql` — ~40KB of generated inserts | listed under "Files skipped for detailed review", NOT reviewed line by line | `cases/large-diff-guards.md` |
+| `db/seeds_dump.sql` — ~40KB of generated inserts | listed under the files-skipped heading, itself written in the output language, NOT reviewed line by line | `cases/large-diff-guards.md` |
 | PR body — every checklist box unchecked | exactly 1 consolidated 🟠 finding | `cases/pr-template-checklist.md` |
 
 Then check the mechanics:

--- a/src/cases/submodule-review.md
+++ b/src/cases/submodule-review.md
@@ -88,14 +88,13 @@ exactly 1 for the submodule PR, never repeated.
 ## Presenting output
 
 2 reviews on 2 different PRs (possibly 2 repos) → display in chat AND in the final summary CLEARLY
-SPLIT, referring to each by PR NUMBER, headings IN THE CHAT LANGUAGE. FORBIDDEN: relative labels like
-"main PR"/"secondary PR":
+SPLIT, referring to each by PR NUMBER. FORBIDDEN: relative labels like "main PR"/"secondary PR":
 
 ```
-### Review of PR #<n-main> (<owner>/<repo>)
+### <"Review of PR", IN THE CHAT LANGUAGE> #<n-main> (<owner>/<repo>)
 (summary + link)
 
-### Review of PR #<n-submodule> (<owner-submodule>/<repo-submodule>)
+### <"Review of PR", IN THE CHAT LANGUAGE> #<n-submodule> (<owner-submodule>/<repo-submodule>)
 (summary + link)
 ```
 

--- a/src/cases/submodule-review.md
+++ b/src/cases/submodule-review.md
@@ -88,7 +88,8 @@ exactly 1 for the submodule PR, never repeated.
 ## Presenting output
 
 2 reviews on 2 different PRs (possibly 2 repos) → display in chat AND in the final summary CLEARLY
-SPLIT, referring to each by PR NUMBER. FORBIDDEN: relative labels like "main PR"/"secondary PR":
+SPLIT, referring to each by PR NUMBER, headings IN THE CHAT LANGUAGE. FORBIDDEN: relative labels like
+"main PR"/"secondary PR":
 
 ```
 ### Review of PR #<n-main> (<owner>/<repo>)

--- a/src/commands/review.md
+++ b/src/commands/review.md
@@ -238,7 +238,7 @@ no finding below does. Nothing such ⇒ stop after the reply instructions.
 #### 🔵 SUGGESTION
 #### 📝 NOTE
 
-#### Files skipped for detailed review
+#### <files skipped, IN THE OUTPUT LANGUAGE>
 - `<path>` — <short reason, e.g. "diff ~35KB, looks like seed/dump data">
 ```
 
@@ -246,11 +246,11 @@ Only FILE findings get the full Fix + path structure; LINE stays inline-only. Be
 `#### <emoji>` heading: ≥1 FILE finding at EXACTLY that severity? No — even if a LINE finding has it,
 even for 📝 → drop the heading. FORBIDDEN: an empty heading, writing "no issues", or a count of N.
 
-A heading carries emoji + label, verbatim as above — it groups findings for someone skimming the PR
-body, who needs the severity named. An individual finding carries the emoji ALONE (Step 7), heading or
-not: there the emoji sits against a description that already says what the problem is.
+A SEVERITY heading carries emoji + label, verbatim as above — it groups findings for someone skimming
+the PR body, who needs the severity named. An individual finding carries the emoji ALONE (Step 7),
+heading or not: there the emoji sits against a description that already says what the problem is.
 
-**Files skipped for detailed review** = the content of `<worktree>/.review-skipped.md` (`Read` it again
+The files-skipped section = the content of `<worktree>/.review-skipped.md` (`Read` it again
 while writing this Step, don't rely on context) → ALWAYS last in the overview WHEN that file exists
 non-empty, even under LGTM, so the user knows what to check personally. Missing/empty → drop the
 heading, never write "none".

--- a/tests/test_prompt_graph.py
+++ b/tests/test_prompt_graph.py
@@ -425,6 +425,24 @@ def test_posted_output_hardcodes_no_english_connective():
     assert not bad, "English pinned into posted output:\n  " + "\n  ".join(bad)
 
 
+SEVERITY_HEADINGS = {"#### 🔴 MUST FIX", "#### 🟠 SHOULD FIX", "#### 🔵 SUGGESTION", "#### 📝 NOTE"}
+
+
+def test_overview_headings_other_than_severity_follow_the_output_language():
+    """The overview template is copied onto the PR heading by heading. The severity ones
+    are a fixed vocabulary and stay as written; every other heading is prose, and one left
+    as a literal shipped `Files skipped for detailed review` above a Vietnamese body.
+
+    A prose heading in the template must therefore say which language it takes.
+    """
+    block = re.search(r"### 🤖【AI REVIEW】Overview\n(.*?)\n```",
+                      text(SRC / "commands" / "review.md"), re.S)
+    assert block, "the overview template block moved — this guard reads it by its heading"
+    bad = [ln for ln in block.group(1).splitlines()
+           if ln.startswith("#### ") and ln not in SEVERITY_HEADINGS and "OUTPUT LANGUAGE" not in ln]
+    assert not bad, "heading pinned in one language inside the overview:\n  " + "\n  ".join(bad)
+
+
 def test_no_harness_auto_exec_syntax():
     """`` !`cmd` `` in a slash-command body is executed by the harness before the model
     ever sees the file. A `!` used as logical NOT next to a backticked field name reads

--- a/tests/test_prompt_graph.py
+++ b/tests/test_prompt_graph.py
@@ -425,9 +425,6 @@ def test_posted_output_hardcodes_no_english_connective():
     assert not bad, "English pinned into posted output:\n  " + "\n  ".join(bad)
 
 
-SEVERITY_HEADINGS = {"#### 🔴 MUST FIX", "#### 🟠 SHOULD FIX", "#### 🔵 SUGGESTION", "#### 📝 NOTE"}
-
-
 def test_overview_headings_other_than_severity_follow_the_output_language():
     """The overview template is copied onto the PR heading by heading. The severity ones
     are a fixed vocabulary and stay as written; every other heading is prose, and one left

--- a/tests/test_prompt_graph.py
+++ b/tests/test_prompt_graph.py
@@ -425,19 +425,23 @@ def test_posted_output_hardcodes_no_english_connective():
     assert not bad, "English pinned into posted output:\n  " + "\n  ".join(bad)
 
 
-def test_overview_headings_other_than_severity_follow_the_output_language():
-    """The overview template is copied onto the PR heading by heading. The severity ones
-    are a fixed vocabulary and stay as written; every other heading is prose, and one left
-    as a literal shipped `Files skipped for detailed review` above a Vietnamese body.
+LANGUAGE_MARKED = re.compile(r"IN THE (OUTPUT|CHAT) LANGUAGE")
+FIXED_HEADINGS = set(SEVERITY_HEADINGS) | {"### 🤖【AI REVIEW】Overview"}
 
-    A prose heading in the template must therefore say which language it takes.
+
+def test_template_headings_other_than_severity_follow_the_language():
+    """A heading inside a fenced template is copied out verbatim, so one pinned in English
+    ships English into a vi/ja review or chat — as `Files skipped for detailed review` did
+    above a Vietnamese body. Severity labels and the AI REVIEW banner are a fixed
+    vocabulary; every other heading names the language it takes.
     """
-    block = re.search(r"### 🤖【AI REVIEW】Overview\n(.*?)\n```",
-                      text(SRC / "commands" / "review.md"), re.S)
-    assert block, "the overview template block moved — this guard reads it by its heading"
-    bad = [ln for ln in block.group(1).splitlines()
-           if ln.startswith("#### ") and ln not in SEVERITY_HEADINGS and "OUTPUT LANGUAGE" not in ln]
-    assert not bad, "heading pinned in one language inside the overview:\n  " + "\n  ".join(bad)
+    bad = []
+    for name in ("commands/review.md", "cases/submodule-review.md"):
+        for block in re.findall(r"\n```\n(.*?)\n```", text(SRC / name), re.S):
+            bad += [f"{name}: {ln}" for ln in block.splitlines()
+                    if re.match(r"#{3,6} ", ln) and ln not in FIXED_HEADINGS
+                    and not LANGUAGE_MARKED.search(ln)]
+    assert not bad, "heading pinned in one language inside a template:\n  " + "\n  ".join(bad)
 
 
 def test_no_harness_auto_exec_syntax():


### PR DESCRIPTION
## Description

`#### Files skipped for detailed review` sat in the overview template as a literal, so it was copied onto the PR verbatim: a `vi` or `ja` review printed an English heading above its own list of skipped files. Same class as the thanks in #34, one heading further down.

The template now marks it as prose that takes the output language. The four severity headings stay verbatim — they are a fixed vocabulary, English like the emoji beside them — and the rule next to the template says exactly that instead of covering all headings at once.

`cases/submodule-review.md` had the same shape in its chat output: two per-PR headings written as literals. They follow the chat language now.

A guard reads the overview template and fails on any `####` heading that is neither one of the four severity headings nor marked with the language it takes. Restoring the old literal turns it red.

## Type of change

- [ ] 🔴 Breaking change (changes config/output behavior that repos using the plugin depend on)
- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] 📝 Docs (README/CLAUDE.md, no runtime behavior change)
- [ ] 🔧 Chore (refactor, tooling, no user-visible behavior change)

## How was this tested

`scripts/check.sh origin/main` — 51 passed, duplication scan clean.

The guard was proven, not assumed: putting `#### Files skipped for detailed review` back into the template fails `test_overview_headings_other_than_severity_follow_the_output_language`, and the template as committed passes.

Not dogfooded against a live run with a non-empty `.review-skipped.md` — that needs an oversized diff to trigger the skip path.

## Checklist

- [x] `scripts/check.sh <base-ref>` passes — suite, duplication scan, context cost
- [x] Context cost: **more expensive**, and no ceiling could be lowered. `review/new-repo-github` +3 (12,210 → 12,213, ceiling 12,218) from the template placeholder; `review/submodule-bump` +11 (11,504 → 11,515, ceiling 11,528), the extra 8 being the chat-language clause in `cases/submodule-review.md`. Compression had nothing left to take: the "every other heading is prose" clause was cut from the rule prose once the template line carried it, which is what paid for the placeholder
- [x] `tests/token-history.json` and `token-history.svg` untouched
- [x] Behavior/architecture change → no `CLAUDE.md` change needed; the output-language rule already lives in `review.md` Step 8
- [x] Anything a user sees → the heading text is chosen at run time per language, so no README or `docs/` page states it; the demo screenshots show reviews with no skipped files
- [x] Added a config field → none
- [x] Changed the config shape → none, no `schema_version` bump
- [x] No new `allowed-tools` grant