### PR TITLE
fix: never read a failed search as zero matches

### DIFF
--- a/scripts/token_report.py
+++ b/scripts/token_report.py
@@ -294,8 +294,9 @@ def main():
     if args.update_budgets:
         b = {"scenarios": {k: int(v["tokens"] * 1.02) for k, v in hs.items()},
              "mean": int(sum(v["tokens"] for v in hs.values()) / len(hs) * 1.02),
-             "_note": "Ceilings measured by scripts/token_report.py (cl100k proxy), +2% headroom. "
-                      "Lower them when a change wins tokens back."}
+             "_note": "Ceilings measured by scripts/token_report.py (cl100k proxy). --update-budgets "
+                      "rewrites EVERY ceiling to measured +2%, RAISING any that were tightened by "
+                      "hand — lower by hand when a change wins tokens back."}
         (REPO / "tests" / "budgets.json").write_text(json.dumps(b, indent=2) + "\n")
         print("\nwrote tests/budgets.json")
 

--- a/src/commands/clean.md
+++ b/src/commands/clean.md
@@ -19,7 +19,7 @@ Same layout `/open-pr:upgrade` searches: `notebooks/review/` sits wherever `/ope
 pwd or one level down. FORBIDDEN: `cd`.
 
 ```bash
-find . -maxdepth 6 -type d -path '*/notebooks/review/*/worktrees/*' 2>&1 | grep -Ev '/worktrees/[^/]+/'
+find . -maxdepth 6 -type d -path '*/notebooks/review/*/worktrees/*' 2>&1 | grep -Ev '^\./.*/worktrees/[^/]+/'
 ```
 
 None → say there is nothing to clean, STOP.

--- a/src/commands/clean.md
+++ b/src/commands/clean.md
@@ -19,7 +19,7 @@ Same layout `/open-pr:upgrade` searches: `notebooks/review/` sits wherever `/ope
 pwd or one level down. FORBIDDEN: `cd`.
 
 ```bash
-find . -maxdepth 6 -type d -path '*/notebooks/review/*/worktrees/*' -not -path '*/worktrees/*/*' 2>/dev/null
+find . -maxdepth 6 -type d -path '*/notebooks/review/*/worktrees/*' 2>&1 | grep -Ev '/worktrees/[^/]+/'
 ```
 
 None → say there is nothing to clean, STOP.

--- a/src/commands/upgrade.md
+++ b/src/commands/upgrade.md
@@ -24,7 +24,7 @@ every repo's side by side, a repo reviewed from inside keeps its own. Search bot
 `cd`, deriving `<repo>` from a git remote (a workspace has none):
 
 ```bash
-find . -maxdepth 4 -type d -path '*/notebooks/review' 2>&1 | grep -Ev '/worktrees/|node_modules'
+find . -maxdepth 4 -type d -path '*/notebooks/review' 2>&1 | grep -Ev '^\./.*(/worktrees/|node_modules)'
 ```
 
 Each hit's subdirectories are the `<set>`s, named `<repo>`; key them by PATH — one `<repo>` may sit under

--- a/src/commands/upgrade.md
+++ b/src/commands/upgrade.md
@@ -24,7 +24,7 @@ every repo's side by side, a repo reviewed from inside keeps its own. Search bot
 `cd`, deriving `<repo>` from a git remote (a workspace has none):
 
 ```bash
-find . -maxdepth 4 -type d -path '*/notebooks/review' -not -path '*/worktrees/*' -not -path '*/node_modules/*'
+find . -maxdepth 4 -type d -path '*/notebooks/review' 2>&1 | grep -Ev '/worktrees/|node_modules'
 ```
 
 Each hit's subdirectories are the `<set>`s, named `<repo>`; key them by PATH — one `<repo>` may sit under

--- a/src/core/guardrails.md
+++ b/src/core/guardrails.md
@@ -13,11 +13,10 @@ specific to what IT may touch; nothing below is repeated there.
 - **A subagent gets the command file VERBATIM** — delegating (Agent tool, anywhere) → it MUST `Read`
   that file and follow it. FORBIDDEN: paraphrasing the rules into a hand-written prompt; paraphrase is
   where drift starts once something commits/pushes/replies on a real PR.
-- **A search that ERRORED searched NOTHING — never 0 matches.** Non-result output line (a shell shim
-  rejecting the command, a permission error) ⇒ FAILED, even on exit 0. FORBIDDEN: reading it as absent,
-  searching above pwd, telling the user the target is not there — print the error, ask for the path.
-  `find` MUST keep 1 predicate set (`-maxdepth -type -iname -path`), exclude via `| grep -Ev`, stderr
-  kept: shims reject `-not`/`-o`/`-exec`, `2>/dev/null` turns that rejection into an empty result.
+- **A search that ERRORED searched NOTHING — never 0 matches.** Non-result output line ⇒ FAILED even on
+  exit 0: print it, ask for the path. FORBIDDEN: reading it as absent, searching above pwd. Keep `find`
+  to 1 predicate set, exclude via `| grep -Ev`, stderr kept — shims reject `-not`/`-o`/`-exec` and
+  `2>/dev/null` hides that rejection.
 - **Choice-based questions use the built-in feature** (e.g. `AskUserQuestion`) when available, else
   plain chat — here and in any file a command leads to. It caps questions per call ⇒ SEQUENTIAL calls,
   one finished before the next, never crammed. Every question carries a pre-marked recommendation — that

--- a/src/core/guardrails.md
+++ b/src/core/guardrails.md
@@ -14,9 +14,10 @@ specific to what IT may touch; nothing below is repeated there.
   that file and follow it. FORBIDDEN: paraphrasing the rules into a hand-written prompt; paraphrase is
   where drift starts once something commits/pushes/replies on a real PR.
 - **A search that ERRORED searched NOTHING — never 0 matches.** Non-result output line ⇒ FAILED even on
-  exit 0: print it, ask for the path. FORBIDDEN: reading it as absent, searching above pwd. Keep `find`
-  to 1 predicate set, exclude via `| grep -Ev`, stderr kept — shims reject `-not`/`-o`/`-exec` and
-  `2>/dev/null` hides that rejection.
+  exit 0: print it, ask for the path. No output && exit ≠ 0 ⇒ 0 matches, NOT a failure. FORBIDDEN:
+  reading a failure as absent, searching above pwd. Keep `find` to 1 predicate set, exclude via `|
+  grep -Ev '^\./…'` — anchored to result lines so an error survives the filter; shims reject
+  `-not`/`-o`/`-exec` and `2>/dev/null` hides that rejection.
 - **Choice-based questions use the built-in feature** (e.g. `AskUserQuestion`) when available, else
   plain chat — here and in any file a command leads to. It caps questions per call ⇒ SEQUENTIAL calls,
   one finished before the next, never crammed. Every question carries a pre-marked recommendation — that

--- a/src/core/guardrails.md
+++ b/src/core/guardrails.md
@@ -13,6 +13,11 @@ specific to what IT may touch; nothing below is repeated there.
 - **A subagent gets the command file VERBATIM** — delegating (Agent tool, anywhere) → it MUST `Read`
   that file and follow it. FORBIDDEN: paraphrasing the rules into a hand-written prompt; paraphrase is
   where drift starts once something commits/pushes/replies on a real PR.
+- **A search that ERRORED searched NOTHING — never 0 matches.** Non-result output line (a shell shim
+  rejecting the command, a permission error) ⇒ FAILED, even on exit 0. FORBIDDEN: reading it as absent,
+  searching above pwd, telling the user the target is not there — print the error, ask for the path.
+  `find` MUST keep 1 predicate set (`-maxdepth -type -iname -path`), exclude via `| grep -Ev`, stderr
+  kept: shims reject `-not`/`-o`/`-exec`, `2>/dev/null` turns that rejection into an empty result.
 - **Choice-based questions use the built-in feature** (e.g. `AskUserQuestion`) when available, else
   plain chat — here and in any file a command leads to. It caps questions per call ⇒ SEQUENTIAL calls,
   one finished before the next, never crammed. Every question carries a pre-marked recommendation — that

--- a/src/core/guardrails.md
+++ b/src/core/guardrails.md
@@ -14,10 +14,9 @@ specific to what IT may touch; nothing below is repeated there.
   that file and follow it. FORBIDDEN: paraphrasing the rules into a hand-written prompt; paraphrase is
   where drift starts once something commits/pushes/replies on a real PR.
 - **A search that ERRORED searched NOTHING — never 0 matches.** Non-result output line ⇒ FAILED even on
-  exit 0: print it, ask for the path. No output && exit ≠ 0 ⇒ 0 matches, NOT a failure. FORBIDDEN:
-  reading a failure as absent, searching above pwd. Keep `find` to 1 predicate set, exclude via `|
-  grep -Ev '^\./…'` — anchored to result lines so an error survives the filter; shims reject
-  `-not`/`-o`/`-exec` and `2>/dev/null` hides that rejection.
+  exit 0: print it, ask for the path, never search above pwd. No output && exit ≠ 0 ⇒ 0 matches, NOT a
+  failure. `find`: 1 predicate set, exclude via `| grep -Ev '^\./…'` anchored to result lines.
+  FORBIDDEN: `-not`/`-o`/`-exec` (shims reject them), `2>/dev/null`.
 - **Choice-based questions use the built-in feature** (e.g. `AskUserQuestion`) when available, else
   plain chat — here and in any file a command leads to. It caps questions per call ⇒ SEQUENTIAL calls,
   one finished before the next, never crammed. Every question carries a pre-marked recommendation — that

--- a/src/core/locate-repo.md
+++ b/src/core/locate-repo.md
@@ -7,7 +7,7 @@ this file's.
 1. `git remote -v` at pwd names `<owner>/<repo>` → `<repo_dir>` = `.`, skip 2. Case-insensitive, both
    `https://<host>/<owner>/<repo>.git` and `git@<host>:<owner>/<repo>.git`, `<host>` = this PR's own URL
    host so self-hosted matches.
-2. Else `find . -maxdepth 4 -type d -iname "$REPO" -not -path '*/node_modules/*' 2>/dev/null`, then
+2. Else `find . -maxdepth 4 -type d -iname "$REPO" 2>&1 | grep -Ev 'node_modules'`, then
    `git -C "<candidate>" remote -v 2>/dev/null` per candidate, cross-checked against `<owner>/<repo>` — a
    matching directory NAME is never enough, the remote MUST match.
    - exactly 1 → that is `<repo_dir>`; state which in 1 short sentence

--- a/src/core/locate-repo.md
+++ b/src/core/locate-repo.md
@@ -7,7 +7,7 @@ this file's.
 1. `git remote -v` at pwd names `<owner>/<repo>` → `<repo_dir>` = `.`, skip 2. Case-insensitive, both
    `https://<host>/<owner>/<repo>.git` and `git@<host>:<owner>/<repo>.git`, `<host>` = this PR's own URL
    host so self-hosted matches.
-2. Else `find . -maxdepth 4 -type d -iname "$REPO" 2>&1 | grep -Ev 'node_modules'`, then
+2. Else `find . -maxdepth 4 -type d -iname "$REPO" 2>&1 | grep -Ev '^\./.*node_modules'`, then
    `git -C "<candidate>" remote -v 2>/dev/null` per candidate, cross-checked against `<owner>/<repo>` — a
    matching directory NAME is never enough, the remote MUST match.
    - exactly 1 → that is `<repo_dir>`; state which in 1 short sentence

--- a/tests/budgets.json
+++ b/tests/budgets.json
@@ -1,18 +1,18 @@
 {
   "scenarios": {
-    "review/new-repo-github": 12598,
-    "review/known-repo-github-clean": 10078,
-    "review/known-repo-gitlab-rereview": 13987,
-    "review/large-diff-multistack": 11889,
-    "review/submodule-bump": 11896,
-    "review/agent-instructions-repo": 10729,
-    "review/post-error-github": 10433,
-    "chat/reconfigure-review": 7716,
-    "upgrade": 2274,
-    "clean": 1344,
-    "fix/known-repo-github": 8554,
-    "fix/first-run-gitlab": 9518
+    "review/new-repo-github": 12559,
+    "review/known-repo-github-clean": 10039,
+    "review/known-repo-gitlab-rereview": 13948,
+    "review/large-diff-multistack": 11850,
+    "review/submodule-bump": 11857,
+    "review/agent-instructions-repo": 10690,
+    "review/post-error-github": 10394,
+    "chat/reconfigure-review": 7677,
+    "upgrade": 2235,
+    "clean": 1305,
+    "fix/known-repo-github": 8515,
+    "fix/first-run-gitlab": 9479
   },
-  "mean": 9251,
+  "mean": 9212,
   "_note": "Ceilings measured by scripts/token_report.py (cl100k proxy), +2% headroom. Lower them when a change wins tokens back."
 }

--- a/tests/budgets.json
+++ b/tests/budgets.json
@@ -1,18 +1,18 @@
 {
   "scenarios": {
-    "review/new-repo-github": 12559,
-    "review/known-repo-github-clean": 10039,
-    "review/known-repo-gitlab-rereview": 13948,
-    "review/large-diff-multistack": 11850,
-    "review/submodule-bump": 11857,
-    "review/agent-instructions-repo": 10690,
-    "review/post-error-github": 10394,
-    "chat/reconfigure-review": 7677,
-    "upgrade": 2235,
-    "clean": 1305,
-    "fix/known-repo-github": 8515,
-    "fix/first-run-gitlab": 9479
+    "review/new-repo-github": 12353,
+    "review/known-repo-github-clean": 9946,
+    "review/known-repo-gitlab-rereview": 13855,
+    "review/large-diff-multistack": 11757,
+    "review/submodule-bump": 11663,
+    "review/agent-instructions-repo": 10597,
+    "review/post-error-github": 10301,
+    "chat/reconfigure-review": 7695,
+    "upgrade": 2250,
+    "clean": 1339,
+    "fix/known-repo-github": 8548,
+    "fix/first-run-gitlab": 9512
   },
-  "mean": 9212,
-  "_note": "Ceilings measured by scripts/token_report.py (cl100k proxy), +2% headroom. Lower them when a change wins tokens back."
+  "mean": 9248,
+  "_note": "Ceilings measured by scripts/token_report.py (cl100k proxy). --update-budgets rewrites EVERY ceiling to measured +2%, RAISING any that were tightened by hand — lower by hand when a change wins tokens back."
 }

--- a/tests/budgets.json
+++ b/tests/budgets.json
@@ -1,18 +1,18 @@
 {
   "scenarios": {
-    "review/new-repo-github": 12218,
-    "review/known-repo-github-clean": 9811,
-    "review/known-repo-gitlab-rereview": 13720,
-    "review/large-diff-multistack": 11622,
-    "review/submodule-bump": 11528,
-    "review/agent-instructions-repo": 10462,
-    "review/post-error-github": 10166,
-    "chat/reconfigure-review": 7560,
-    "upgrade": 2115,
-    "clean": 1201,
-    "fix/known-repo-github": 8413,
-    "fix/first-run-gitlab": 9377
+    "review/new-repo-github": 12598,
+    "review/known-repo-github-clean": 10078,
+    "review/known-repo-gitlab-rereview": 13987,
+    "review/large-diff-multistack": 11889,
+    "review/submodule-bump": 11896,
+    "review/agent-instructions-repo": 10729,
+    "review/post-error-github": 10433,
+    "chat/reconfigure-review": 7716,
+    "upgrade": 2274,
+    "clean": 1344,
+    "fix/known-repo-github": 8554,
+    "fix/first-run-gitlab": 9518
   },
-  "mean": 9730,
-  "_note": "Ceilings measured by scripts/token_report.py (cl100k proxy). --update-budgets rewrites EVERY ceiling to measured +2%, RAISING any that were tightened by hand — lower by hand when a change wins tokens back."
+  "mean": 9251,
+  "_note": "Ceilings measured by scripts/token_report.py (cl100k proxy), +2% headroom. Lower them when a change wins tokens back."
 }

--- a/tests/budgets.json
+++ b/tests/budgets.json
@@ -1,18 +1,18 @@
 {
   "scenarios": {
-    "review/new-repo-github": 12410,
-    "review/known-repo-github-clean": 10003,
-    "review/known-repo-gitlab-rereview": 13912,
-    "review/large-diff-multistack": 11814,
-    "review/submodule-bump": 11720,
-    "review/agent-instructions-repo": 10654,
-    "review/post-error-github": 10358,
-    "chat/reconfigure-review": 7752,
-    "upgrade": 2250,
-    "clean": 1339,
-    "fix/known-repo-github": 8605,
-    "fix/first-run-gitlab": 9569
+    "review/new-repo-github": 12393,
+    "review/known-repo-github-clean": 9986,
+    "review/known-repo-gitlab-rereview": 13895,
+    "review/large-diff-multistack": 11797,
+    "review/submodule-bump": 11703,
+    "review/agent-instructions-repo": 10637,
+    "review/post-error-github": 10341,
+    "chat/reconfigure-review": 7735,
+    "upgrade": 2233,
+    "clean": 1322,
+    "fix/known-repo-github": 8588,
+    "fix/first-run-gitlab": 9552
   },
-  "mean": 9295,
+  "mean": 9278,
   "_note": "Ceilings measured by scripts/token_report.py (cl100k proxy), +2% headroom. --update-budgets rewrites EVERY ceiling, RAISING any that was tightened by hand — lower them by hand when a change wins tokens back."
 }


### PR DESCRIPTION
## Description

A search whose command is rejected writes the refusal to stderr and can still exit 0, so
`find … 2>/dev/null` looked exactly like a search that ran and matched nothing. Every caller of one
read that silence as "the target is not here":

```
$ find . -maxdepth 4 -type d -iname "$REPO" -not -path '*/node_modules/*' 2>/dev/null
$ echo $?
1
$ command find . -maxdepth 4 -type d -iname "$REPO" -not -path '*/node_modules/*' 2>&1
<shim>: find does not support compound predicates or actions (e.g. -not, -exec). Use `find` directly.
```

`command find` does not get around it — a shim that wraps `find` sits above the shell. Shims are one
trigger; an unreadable directory, an aliased `find`, or a build without `-maxdepth` produce the same
silence.

What that cost, per command:

| command | reported | reality |
|---|---|---|
| `review` / `fix` (`core/locate-repo.md`) | repo of the PR not on the machine — then widened the search up to `$HOME` at depth 6 before asking | it sat one level below pwd |
| `clean` | nothing to clean | worktrees present |
| `upgrade` | nothing set up here, bootstrap first | config sets present |

The first is the one that bites: the user is standing in the workspace holding the repo and gets told
it does not exist anywhere.

Two changes:

- Every `find` keeps a single predicate set and excludes by piping to `grep -Ev '^\./…'`, stderr kept.
  The anchor is what makes it safe: `find .` prints results as `./…` while an error opens with the
  tool's name, so the exclusion can no longer swallow the error along with the paths it is meant to
  drop.
- `core/guardrails.md` — which all four commands already read — states the rule both ways, so a search
  an agent composes itself cannot rebuild the trap: a non-result line means the search FAILED even on
  exit 0, and silence with a non-zero status means 0 matches, since `grep` exits 1 when nothing
  matches and an empty result is the normal path for `clean` and `upgrade`.

Merged `main` after #42 landed. Both branches had restored the hand-tightening warning to the `_note`
that `--update-budgets` stamps; `main` says it already, so this branch dropped its own wording and
`scripts/token_report.py` is now identical to `main`.

## Type of change

- [ ] 🔴 Breaking change (changes config/output behavior that repos using the plugin depend on)
- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] 📝 Docs (README/CLAUDE.md, no runtime behavior change)
- [ ] 🔧 Chore (refactor, tooling, no user-visible behavior change)

## How was this tested

`scripts/check.sh origin/main` — 66 passed, duplication scan clean.

Each rewritten command was run beside the one it replaces, on a fixture tree carrying both an
excluded path and an unreadable directory, since a filter that looks equivalent is not one:

```
ws/
├── xxx-web/                                            <- the target
├── repo-a/node_modules/xxx-web/                        <- must stay excluded
├── repo-a/node_modules/locked/                         <- chmod 000, makes find emit an error
├── repo-a/notebooks/review/repo-a/worktrees/pr3-77/
├── notebooks/review/repo-a/worktrees/pr1-99/src/deep/  <- nested, must not be listed
└── notebooks/review/repo-b/worktrees/pr2-88/
```

| search | results | the error line |
|---|---|---|
| locate-repo | `./xxx-web`, `node_modules` copy excluded | survives the filter |
| clean | the 3 worktree roots, `pr1-99/src` excluded | survives the filter |
| upgrade | `./notebooks/review`, `./repo-a/notebooks/review` | survives the filter |

Removing the unreadable directory reproduces the previous commands' result sets exactly, order aside.
A genuinely empty search returns no output and exit 1, which is the case the guardrail's second
direction now names.

Not dogfooded against a live PR — the failing path needs a shim that rejects compound predicates, and
the fixture reproduces it deterministically.

## Checklist

- [x] `scripts/check.sh <base-ref>` passes — suite, duplication scan, context cost
- [x] Context cost: **more expensive, +118 tokens on every scenario** (`clean` +121 / +10.3%,
  `upgrade` +118 / +5.6%, each `review` and `fix` +118 / ~1.0-1.4%, mean +119). The guardrail is the
  only place the rule works from — a command-local copy would cost four copies and still miss
  whichever search comes next. What is left is the two directions of the rule, the anchor, and the
  banned constructs; nothing states the same thing twice and no clause explains rather than instructs.
  Ceilings were **not** written by `--update-budgets`, which would have raised every one to measured
  +2% and erased the hand-tightening on `main`. Each is the measurement plus the slack that scenario
  had on `main` (e.g. `review/new-repo-github`: measured 12,388, slack +5 → 12,393), so the +118 above
  is the whole movement. `mean` takes the tighter of the two derivations
- [x] `tests/token-history.json` and `token-history.svg` untouched
- [x] Behavior/architecture change → updated `CLAUDE.md` accordingly — n/a, no rule in `CLAUDE.md`
  describes search commands or guardrail contents
- [x] Anything a user sees → all 3 READMEs + `docs/` — n/a, no command, flow, default or setup
  question changes; only what happens when a search fails
- [x] Added a config field — n/a
- [x] Changed the config shape an EXISTING repo already has — n/a, no `schema_version` bump
- [x] No new `allowed-tools` grant — n/a, none added

