### PR TITLE
chore(chart): context cost at v1.3.0

### DIFF
--- a/tests/token-history.json
+++ b/tests/token-history.json
@@ -76,6 +76,15 @@
       "fix": 8896,
       "upgrade": 2211,
       "clean": 1299
+    },
+    {
+      "tag": "v1.3.0",
+      "date": "2026-08-17",
+      "review": 11655,
+      "fix": 9585,
+      "upgrade": 2211,
+      "clean": 1299,
+      "feedback": 2078
     }
   ]
 }

--- a/token-history.svg
+++ b/token-history.svg
@@ -20,54 +20,62 @@
 <line x1="62" y1="38.0" x2="702" y2="38.0" stroke="#8b949e" stroke-opacity="0.25"/>
 <text x="54" y="41.5" text-anchor="end" font-size="10" fill="#8b949e">18k</text>
 <text x="78.0" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.1.0</text>
-<text x="145.6" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.0</text>
-<text x="213.1" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.1</text>
-<text x="280.7" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.3.0</text>
-<text x="348.2" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.0.0</text>
-<text x="415.8" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.0</text>
-<text x="483.3" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.1</text>
-<text x="550.9" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.2</text>
-<text x="618.4" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.0</text>
-<text x="686.0" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.1</text>
-<polyline points="78.0,113.9 145.6,62.8 213.1,68.3 280.7,53.0 348.2,108.5 415.8,108.2 483.3,108.4 550.9,108.3 618.4,108.3 686.0,106.6" fill="none" stroke="#2f81f7" stroke-width="2" stroke-linejoin="round"/>
+<text x="138.8" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.0</text>
+<text x="199.6" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.1</text>
+<text x="260.4" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.3.0</text>
+<text x="321.2" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.0.0</text>
+<text x="382.0" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.0</text>
+<text x="442.8" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.1</text>
+<text x="503.6" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.2</text>
+<text x="564.4" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.0</text>
+<text x="625.2" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.1</text>
+<text x="686.0" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.3.0</text>
+<polyline points="78.0,113.9 138.8,62.8 199.6,68.3 260.4,53.0 321.2,108.5 382.0,108.2 442.8,108.4 503.6,108.3 564.4,108.3 625.2,106.6 686.0,100.0" fill="none" stroke="#2f81f7" stroke-width="2" stroke-linejoin="round"/>
 <circle cx="78.0" cy="113.9" r="3" fill="#2f81f7"/>
-<circle cx="145.6" cy="62.8" r="3" fill="#2f81f7"/>
-<circle cx="213.1" cy="68.3" r="3" fill="#2f81f7"/>
-<circle cx="280.7" cy="53.0" r="3" fill="#2f81f7"/>
-<circle cx="348.2" cy="108.5" r="3" fill="#2f81f7"/>
-<circle cx="415.8" cy="108.2" r="3" fill="#2f81f7"/>
-<circle cx="483.3" cy="108.4" r="3" fill="#2f81f7"/>
-<circle cx="550.9" cy="108.3" r="3" fill="#2f81f7"/>
-<circle cx="618.4" cy="108.3" r="3" fill="#2f81f7"/>
-<circle cx="686.0" cy="106.6" r="3" fill="#2f81f7"/>
-<polyline points="280.7,84.6 348.2,130.1 415.8,130.1 483.3,128.7 550.9,128.7 618.4,128.7 686.0,127.0" fill="none" stroke="#e3742f" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="280.7" cy="84.6" r="3" fill="#e3742f"/>
-<circle cx="348.2" cy="130.1" r="3" fill="#e3742f"/>
-<circle cx="415.8" cy="130.1" r="3" fill="#e3742f"/>
-<circle cx="483.3" cy="128.7" r="3" fill="#e3742f"/>
-<circle cx="550.9" cy="128.7" r="3" fill="#e3742f"/>
-<circle cx="618.4" cy="128.7" r="3" fill="#e3742f"/>
-<circle cx="686.0" cy="127.0" r="3" fill="#e3742f"/>
-<polyline points="348.2,193.5 415.8,193.5 483.3,193.5 550.9,193.5 618.4,193.5 686.0,192.4" fill="none" stroke="#a371f7" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="348.2" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="415.8" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="483.3" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="550.9" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="618.4" cy="193.5" r="3" fill="#a371f7"/>
+<circle cx="138.8" cy="62.8" r="3" fill="#2f81f7"/>
+<circle cx="199.6" cy="68.3" r="3" fill="#2f81f7"/>
+<circle cx="260.4" cy="53.0" r="3" fill="#2f81f7"/>
+<circle cx="321.2" cy="108.5" r="3" fill="#2f81f7"/>
+<circle cx="382.0" cy="108.2" r="3" fill="#2f81f7"/>
+<circle cx="442.8" cy="108.4" r="3" fill="#2f81f7"/>
+<circle cx="503.6" cy="108.3" r="3" fill="#2f81f7"/>
+<circle cx="564.4" cy="108.3" r="3" fill="#2f81f7"/>
+<circle cx="625.2" cy="106.6" r="3" fill="#2f81f7"/>
+<circle cx="686.0" cy="100.0" r="3" fill="#2f81f7"/>
+<polyline points="260.4,84.6 321.2,130.1 382.0,130.1 442.8,128.7 503.6,128.7 564.4,128.7 625.2,127.0 686.0,120.3" fill="none" stroke="#e3742f" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="260.4" cy="84.6" r="3" fill="#e3742f"/>
+<circle cx="321.2" cy="130.1" r="3" fill="#e3742f"/>
+<circle cx="382.0" cy="130.1" r="3" fill="#e3742f"/>
+<circle cx="442.8" cy="128.7" r="3" fill="#e3742f"/>
+<circle cx="503.6" cy="128.7" r="3" fill="#e3742f"/>
+<circle cx="564.4" cy="128.7" r="3" fill="#e3742f"/>
+<circle cx="625.2" cy="127.0" r="3" fill="#e3742f"/>
+<circle cx="686.0" cy="120.3" r="3" fill="#e3742f"/>
+<polyline points="321.2,193.5 382.0,193.5 442.8,193.5 503.6,193.5 564.4,193.5 625.2,192.4 686.0,192.4" fill="none" stroke="#a371f7" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="321.2" cy="193.5" r="3" fill="#a371f7"/>
+<circle cx="382.0" cy="193.5" r="3" fill="#a371f7"/>
+<circle cx="442.8" cy="193.5" r="3" fill="#a371f7"/>
+<circle cx="503.6" cy="193.5" r="3" fill="#a371f7"/>
+<circle cx="564.4" cy="193.5" r="3" fill="#a371f7"/>
+<circle cx="625.2" cy="192.4" r="3" fill="#a371f7"/>
 <circle cx="686.0" cy="192.4" r="3" fill="#a371f7"/>
-<polyline points="415.8,202.6 483.3,202.5 550.9,202.5 618.4,202.5 686.0,201.3" fill="none" stroke="#3fb950" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="415.8" cy="202.6" r="3" fill="#3fb950"/>
-<circle cx="483.3" cy="202.5" r="3" fill="#3fb950"/>
-<circle cx="550.9" cy="202.5" r="3" fill="#3fb950"/>
-<circle cx="618.4" cy="202.5" r="3" fill="#3fb950"/>
+<polyline points="382.0,202.6 442.8,202.5 503.6,202.5 564.4,202.5 625.2,201.3 686.0,201.3" fill="none" stroke="#3fb950" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="382.0" cy="202.6" r="3" fill="#3fb950"/>
+<circle cx="442.8" cy="202.5" r="3" fill="#3fb950"/>
+<circle cx="503.6" cy="202.5" r="3" fill="#3fb950"/>
+<circle cx="564.4" cy="202.5" r="3" fill="#3fb950"/>
+<circle cx="625.2" cy="201.3" r="3" fill="#3fb950"/>
 <circle cx="686.0" cy="201.3" r="3" fill="#3fb950"/>
+<circle cx="686.0" cy="193.7" r="3" fill="#db61a2"/>
 <circle cx="66" cy="18" r="3.5" fill="#2f81f7"/>
-<text x="75" y="21.5" font-size="11" fill="#8b949e">/open-pr:review 10,984</text>
+<text x="75" y="21.5" font-size="11" fill="#8b949e">/open-pr:review 11,655</text>
 <circle cx="246.0" cy="18" r="3.5" fill="#e3742f"/>
-<text x="255.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:fix 8,896</text>
+<text x="255.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:fix 9,585</text>
 <circle cx="398.0" cy="18" r="3.5" fill="#a371f7"/>
 <text x="407.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:upgrade 2,211</text>
 <circle cx="578.0" cy="18" r="3.5" fill="#3fb950"/>
 <text x="587.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:clean 1,299</text>
+<circle cx="744.0" cy="18" r="3.5" fill="#db61a2"/>
+<text x="753.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:feedback 2,078</text>
 <text x="62" y="252" font-size="9" fill="#8b949e" fill-opacity="0.85">mean per group · cl100k_base proxy · each point frozen at its release · tests/token-history.json</text>
 </svg>


### PR DESCRIPTION
One point per release tag on the context-cost chart. Measured at v1.3.0 by `scripts/token_chart.py --add`; the SVG is redrawn from those numbers, not hand-edited.

review=11655 · fix=9585 · upgrade=2211 · clean=1299 · feedback=2078