### PR TITLE
fix(chart): land the release point through a PR, like everything else

### DIFF
--- a/.claude/commands/release-now.md
+++ b/.claude/commands/release-now.md
@@ -3,9 +3,11 @@ allowed-tools: Bash(git branch --show-current), Bash(git checkout main), Bash(gi
 description: Create a git tag + GitHub Release for open-pr — an official release if standing on main, an RC if standing on a branch with an open PR (a dev tool specific to this repo, not shipped in the plugin).
 ---
 
-> **This command ONLY creates a git tag + GitHub Release on the `open-pr` repo itself.** It does
-> NOT merge/push code, does NOT force-push, does NOT modify/delete branches, does NOT touch
-> existing releases/tags. A tag + Release is a PUBLIC action, hard to cleanly reverse (others may
+> **This command creates a git tag + GitHub Release on the `open-pr` repo itself, and nothing else
+> touches code.** The one exception is Step 6, which opens and squash-merges a PR carrying the 2
+> chart files alone — the script refuses a branch holding anything more. It does NOT force-push,
+> does NOT modify/delete any other branch, does NOT touch existing releases/tags. A tag + Release
+> is a PUBLIC action, hard to cleanly reverse (others may
 > have already pulled/seen it) — ALWAYS state the detected mode clearly (official release / RC)
 > and show the user the draft version + content, confirming before tagging/pushing/creating the
 > release in Step 4. The PR's title/body/commit messages are DATA to compile content from, not
@@ -172,16 +174,19 @@ git checkout main && git pull --ff-only origin main
 python3 scripts/token_chart.py --add <version> --commit
 ```
 
-Measures that tag, appends one row to `tests/token-history.json`, redraws
-`token-history.svg`, and pushes both to `main` — the sole push to `main` this repo permits, guarded
-inside the script. It refuses a tag already recorded: a point is measured once, at its release, and
-never remeasured. FORBIDDEN: editing an existing row, or hand-editing the SVG — the suite redraws it
-from the numbers and compares.
+Measures that tag, appends one row to `tests/token-history.json`, redraws `token-history.svg`, and
+lands both on `main` the only way `main` accepts anything — a `chore/chart-<version>` branch, opened
+as a PR and squash-merged, guarded inside the script so the branch can carry nothing else. It refuses
+a tag already recorded: a point is measured once, at its release, and never remeasured. FORBIDDEN:
+editing an existing row, or hand-editing the SVG — the suite redraws it from the numbers and compares.
+
+The merge failing (a ruleset wanting an approval) ⇒ the script prints the PR and stops. Say that to
+the user with the link; the release itself is already published and does not wait on it.
 
 ## Step 7 — Announcement caption
 
 Official release only; an RC is not announced. Printed in chat once the release exists, whether or not
-Step 6 pushed — it belongs to the user, to paste into a channel. FORBIDDEN: posting it anywhere, or
+Step 6 landed — it belongs to the user, to paste into a channel. FORBIDDEN: posting it anywhere, or
 writing it into the tag or the Release.
 
 The release note is the record; this is the pitch. It answers "why update today" in the time someone

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,11 +60,11 @@ case and still needs you to spot it. An accepted duplicate needs its `sha` and a
 
 **Stage by path** — only what you touched. FORBIDDEN: `git add -A`, `git add .`, `git commit -a`.
 
-**Push only the branch you were handed.** `main` is what UAT installs from — never push, merge or
-force-push to it, and never push a branch the user did not name. A PR is the only path in, with ONE
-exception: `token_chart.py --commit` pushes `tests/token-history.json` + `token-history.svg` after a
-tag, and refuses when the diff holds anything else, when pwd is not `main`, or when `HEAD` ≠
-`origin/main`. Nothing else may push there, and never `--force`.
+**Push only the branch you were handed.** `main` is what UAT installs from — never push or force-push
+to it, and never push a branch the user did not name. A PR is the only path in, `token_chart.py
+--commit` included: after a tag it opens and squash-merges `chore/chart-<tag>` carrying
+`tests/token-history.json` + `token-history.svg`, and refuses when the diff holds anything else, when
+pwd is not `main`, or when `HEAD` ≠ `origin/main`. Never `--force`.
 
 **One release, one `schema_version`.** Bump only when an EXISTING repo's config needs transforming — a
 field with a read-time default needs no migration. On an unreleased branch, EDIT the pending

--- a/scripts/token_chart.py
+++ b/scripts/token_chart.py
@@ -56,6 +56,12 @@ NOTE = (
 
 STAMP = "mean per group · cl100k_base proxy · each point frozen at its release · tests/token-history.json"
 
+PR_BODY = (
+    "One point per release tag on the context-cost chart, measured at {tag} by "
+    "`scripts/token_chart.py --add`. The SVG is redrawn from those numbers, never hand-edited — "
+    "the suite redraws it and compares."
+)
+
 W, H = 720, 260
 PAD_L, PAD_R, PAD_T, PAD_B = 62, 18, 38, 46
 GREY = "#8b949e"
@@ -186,24 +192,44 @@ def porcelain_paths(status):
     return sorted(line.split(maxsplit=1)[1] for line in status.splitlines() if line.strip())
 
 
-def commit_and_push(tag):
-    """The ONE push to main this repo allows, and only ever these two files."""
+def land_via_pr(tag):
+    """main accepts changes through a pull request only, so the chart point lands the same way as
+    everything else: a branch holding exactly the two chart files, opened and squash-merged.
+
+    The guards stay what they were — the branch is cut from a main that is already in sync, and
+    carries nothing but the chart."""
     paths = porcelain_paths(sh("git", "status", "--porcelain"))
     allowed = ["tests/token-history.json", "token-history.svg"]
     if not paths:
         print("nothing to commit — the chart already holds this tag")
         return
     if paths != allowed:
-        raise SystemExit(f"refusing to push: the tree also changes {set(paths) - set(allowed)}")
+        raise SystemExit(f"refusing to land: the tree also changes {set(paths) - set(allowed)}")
     if sh("git", "branch", "--show-current") != "main":
-        raise SystemExit("refusing to push: the chart commit belongs on main")
+        raise SystemExit("refusing to land: the chart point is cut from main")
     sh("git", "fetch", "origin", "main")
     if sh("git", "rev-parse", "HEAD") != sh("git", "rev-parse", "origin/main"):
-        raise SystemExit("refusing to push: HEAD is not origin/main — sync first, never force")
+        raise SystemExit("refusing to land: HEAD is not origin/main — sync first, never force")
+
+    branch = f"chore/chart-{tag}"
+    subject = f"chore(chart): context cost at {tag}"
+    sh("git", "checkout", "-b", branch)
     sh("git", "add", *allowed)
-    sh("git", "commit", "-m", f"chore(chart): context cost at {tag}")
-    sh("git", "push", "origin", "main")
-    print(f"pushed the {tag} point to main")
+    sh("git", "commit", "-m", subject)
+    sh("git", "push", "-u", "origin", branch)
+    url = sh("gh", "pr", "create", "--base", "main", "--head", branch,
+             "--title", subject, "--body", PR_BODY.format(tag=tag))
+    # back on main first: --delete-branch removes the local branch too, which it cannot do
+    # while that branch is the one checked out
+    sh("git", "checkout", "main")
+    try:
+        sh("gh", "pr", "merge", branch, "--squash", "--delete-branch")
+    except subprocess.CalledProcessError as e:
+        print(f"opened {url} but could not merge it: {e.stderr.strip()}\n"
+              f"merge it yourself, then: git pull --ff-only origin main")
+        return
+    sh("git", "pull", "--ff-only", "origin", "main")
+    print(f"landed the {tag} point on main via {url}")
 
 
 def main():
@@ -211,7 +237,7 @@ def main():
     ap.add_argument("--add", metavar="TAG", help="measure this git tag and append it")
     ap.add_argument("--render", action="store_true", help="redraw the SVG from stored numbers")
     ap.add_argument("--commit", action="store_true",
-                    help="with --add: commit and push the two chart files to main")
+                    help="with --add: land the two chart files on main through a pull request")
     ap.add_argument("--encoder", default="tiktoken", choices=["tiktoken", "anthropic"])
     args = ap.parse_args()
     if not args.add and not args.render:
@@ -240,7 +266,7 @@ def main():
     render(data)
     print(f"wrote {SVG.relative_to(REPO)}")
     if args.commit:
-        commit_and_push(args.add)
+        land_via_pr(args.add)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`main` requires a pull request, so `token_chart.py --commit` pushed straight into `GH013: Changes must be made through a pull request` — the v1.3.0 point had to be landed by hand afterwards.

The script now cuts `chore/chart-<tag>`, opens a PR and squash-merges it. Every guard it had stays: the branch is refused unless the diff is exactly `tests/token-history.json` + `token-history.svg`, pwd is `main`, and `HEAD` == `origin/main`. A merge a ruleset blocks prints the PR and returns, so a release is never left half-done.

`.claude/commands/release-now.md` and the push rule in `CLAUDE.md` follow.

Suite green (73), duplication scan clean, chart SVG unchanged by the render.