### PR TITLE
fix(review): a low-severity Fix must not ship a design the dev never chose

### DIFF
--- a/src/commands/review.md
+++ b/src/commands/review.md
@@ -164,6 +164,11 @@ finding inside `comments[]`.
 - the Context "Diff" is the sole source for the files it contains — never refetch it. An "Oversized
   paths" file is absent BY DESIGN; the guard above owns how it gets read
 - never read library source unless genuinely unsure
+- an invariant the code asserts about ITSELF (usually a comment in a region read anyway): hold each
+  mechanism this PR introduces AND each fix about to be proposed against it. Breaks it ⇒ a finding, or a
+  fix to redesign
+- "repeated across call sites" as a finding's nature ⇒ search for EVERY site, list them all; an artifact
+  cited in it as evidence or mitigation stays a SUBJECT of it
 - never pad the count with trivia; there is no minimum N
 
 **Finding format** — every `<…>` is a placeholder to REPLACE, never to print, `<Fix>` being that word in
@@ -189,8 +194,11 @@ fix now is 🔵, not 📝. Each finding carries its own emoji, whatever heading 
 
 The fix shows the corrected CODE in a fence by default: a LINE comment replacing that exact line ⇒
 ` ```suggestion `, anything else ⇒ a normal language fence. Inline code inside prose is NOT a substitute.
-Prose-only ⇔ the fix has no code form (a missing test, a spec to reconfirm) — FORBIDDEN: prose when the
-code is writable.
+Prose-only ⇔ the fix has no code form (a missing test, a spec to reconfirm), || at 🔵/📝 it would INTRODUCE
+state outliving one call (module/global var, cache, memo, singleton, timer, retry loop) — the dev's design
+choice ⇒ name the constraint + the failure to avoid, || raise the severity and keep the code.
+Reworking state already there (another cache key, an invalidation in an existing mutation) introduces none
+⇒ code. FORBIDDEN: prose anywhere else the code is writable.
 
 ≥2 independent points (common on LINE) → one `-` bullet each, never one multi-clause sentence.
 

--- a/tests/budgets.json
+++ b/tests/budgets.json
@@ -1,22 +1,22 @@
 {
   "scenarios": {
-    "review/new-repo-github": 12758,
-    "review/known-repo-github-clean": 10186,
-    "review/known-repo-gitlab-rereview": 14171,
-    "review/large-diff-multistack": 12051,
-    "review/submodule-bump": 12004,
-    "review/agent-instructions-repo": 10891,
-    "review/post-error-github": 10595,
-    "chat/reconfigure-review": 7735,
+    "review/new-repo-github": 12938,
+    "review/known-repo-github-clean": 10366,
+    "review/known-repo-gitlab-rereview": 14351,
+    "review/large-diff-multistack": 12231,
+    "review/submodule-bump": 12184,
+    "review/agent-instructions-repo": 11071,
+    "review/post-error-github": 10775,
+    "chat/reconfigure-review": 7915,
     "upgrade": 2233,
     "clean": 1322,
-    "review/known-repo-bitbucket-clean": 12948,
-    "review/known-repo-bitbucket-rereview": 14944,
+    "review/known-repo-bitbucket-clean": 13128,
+    "review/known-repo-bitbucket-rereview": 15124,
     "fix/known-repo-bitbucket": 10967,
     "fix/known-repo-github": 8588,
     "fix/first-run-gitlab": 9552,
     "feedback": 2120
   },
-  "mean": 9525,
-  "_note": "Ceilings measured by scripts/token_report.py (cl100k proxy); some are tightened by hand below that. --update-budgets rewrites EVERY ceiling to measured +2%, RAISING any that was tightened by hand \u2014 lower them by hand when a change wins tokens back."
+  "mean": 9638,
+  "_note": "Ceilings measured by scripts/token_report.py (cl100k proxy); some are tightened by hand below that. --update-budgets rewrites EVERY ceiling to measured +2%, RAISING any that was tightened by hand — lower them by hand when a change wins tokens back."
 }

--- a/tests/test_prompt_graph.py
+++ b/tests/test_prompt_graph.py
@@ -478,10 +478,32 @@ def test_review_writes_at_the_invocation_directory():
 
 def test_fix_suggestions_prefer_a_code_fence():
     """A finding whose Fix is prose makes the dev reconstruct the intended logic. The
-    fence is the default; prose is for fixes with no code form."""
-    step7 = text(SRC / "commands" / "review.md")
+    fence is the default; prose is for a fix with no code form, and for one whose code
+    would be a design decision the dev owns — reviewer-authored code ships unreviewed,
+    so a minor note must not carry an architecture."""
+    step7 = " ".join(text(SRC / "commands" / "review.md").split())
     assert "shows the corrected CODE in a fence by default" in step7
-    assert "FORBIDDEN: prose when the" in step7, "prose must be the exception, not a sibling option"
+    assert "FORBIDDEN: prose anywhere else the" in step7, \
+        "prose must be the exception, not a sibling option"
+    assert "at 🔵/📝 it would INTRODUCE state outliving one call" in step7, \
+        "the low-severity fix must not introduce state the dev never chose"
+    assert "raise the severity and keep the code" in step7, \
+        "the escape from prose is a higher severity, not a silent downgrade"
+
+
+def test_review_checks_its_own_output_against_the_code():
+    """Two defects belong to no single hunk. One lives where a mechanism meets an invariant
+    the code already states about itself; the other is a claim of repetition made without
+    counting. Both need Step 7 to look past the hunk it is on."""
+    step7 = " ".join(text(SRC / "commands" / "review.md").split())
+    assert "an invariant the code asserts about ITSELF" in step7, \
+        "Step 7 must collect the invariants the code states"
+    assert "each fix about to be proposed against it" in step7, \
+        "the invariant check must cover the review's own fixes, not the diff alone"
+    assert "search for EVERY site, list them all" in step7, \
+        "a repetition finding must enumerate, not sample"
+    assert "stays a SUBJECT of it" in step7, \
+        "citing an artifact as evidence must not exempt it from the same finding"
 
 
 def test_chat_does_not_repeat_the_posted_findings():


### PR DESCRIPTION
## Description

Code inside a `**Fix**` block is the only code in the flow nothing reviews, yet a dev can apply it verbatim. Step 7's `FORBIDDEN: prose when the code is writable` made that worse: for a concurrency or caching concern the code always *is* writable, so a 🔵 SUGGESTION had to commit to one design instead of stating the constraint.

Step 7 now sends such a fix to prose, or raises the severity:

> Prose-only ⇔ the fix has no code form (a missing test, a spec to reconfirm), || at 🔵/📝 it would INTRODUCE state outliving one call (module/global var, cache, memo, singleton, timer, retry loop) — the dev's design choice ⇒ name the constraint + the failure to avoid, || raise the severity and keep the code. Reworking state already there (another cache key, an invalidation in an existing mutation) introduces none ⇒ code.

That last sentence is the guard against the exception swallowing the rule: without it, every finding touching a cache reads as an excuse to skip the fence.

Two misses that belong to no single hunk get a Scope rule each:

- an invariant the code asserts about itself — usually already a comment in a region read anyway — is held against every mechanism the PR introduces **and** every fix the review is about to propose
- a finding whose nature is "repeated across call sites" must enumerate every site; an artifact cited inside it as evidence or mitigation stays a subject of it

Closes #44. Its proposals #4 (attributing a new finding to a previous round's `**Fix**`) and the non-goal (declaring what went unverified) are deliberately out: hunk-to-fix matching across rounds is too fuzzy to state plainly, and coverage gaps already have an owner in the files-skipped section, which `FORBIDDEN: the agent's own WORK PROCESS` keeps the overview from growing into.

## Type of change

- [ ] 🔴 Breaking change (changes config/output behavior that repos using the plugin depend on)
- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] 📝 Docs (README/CLAUDE.md, no runtime behavior change)
- [ ] 🔧 Chore (refactor, tooling, no user-visible behavior change)

## How was this tested

`scripts/check.sh origin/main` — 74 passed, duplication scan clean.

`test_fix_suggestions_prefer_a_code_fence` pinned the removed clause, so it now asserts the rewritten rule plus its two escapes; `test_review_checks_its_own_output_against_the_code` is new and locks the invariant and call-site rules.

Not dogfooded against a live PR yet — the behaviour it changes only shows on a finding whose fix would introduce state.

## Checklist

- [x] `scripts/check.sh <base-ref>` passes — suite, duplication scan, context cost
- [x] Context cost: **more expensive — +180 tokens on every `review/*` scenario** (+1.2–1.8%; `chat/reconfigure-review` +2.3%; mean 9,430 → 9,543). `fix/*`, `upgrade`, `clean`, `feedback` unchanged. Three rules were added, so the cost is new content, not a regression. Two compression passes took it from +213 to +180 — dropping the "free checklist item" framing (the parenthetical already carries it) and shortening the design-choice clause. What is left is the introduce-vs-rework boundary and its example, and cutting those is what makes the exception exploitable. Ceilings raised by hand by exactly that amount so the headroom tightened by hand elsewhere stays where it is; `--update-budgets` would have raised those too.
- [x] `tests/token-history.json` and `token-history.svg` untouched — the chart takes one frozen point per release (`/release-now`), never one per PR
- [x] Behavior/architecture change → updated `CLAUDE.md` accordingly — n/a: `CLAUDE.md` owns the repo's own working rules, not the review criteria
- [x] Anything a user sees — n/a: no doc page describes the shape of a `**Fix**` block, so none goes stale
- [x] Added a config field — n/a
- [x] Changed the config shape an EXISTING repo already has — n/a, no `schema_version` bump
- [x] No new `allowed-tools` grant is broader than necessary — none added
