### PR TITLE
chore(chart): context cost at v1.4.0

### DIFF
--- a/tests/token-history.json
+++ b/tests/token-history.json
@@ -85,6 +85,15 @@
       "upgrade": 2211,
       "clean": 1299,
       "feedback": 2078
+    },
+    {
+      "tag": "v1.4.0",
+      "date": "2026-08-20",
+      "review": 11360,
+      "fix": 9400,
+      "upgrade": 2209,
+      "clean": 1295,
+      "feedback": 2075
     }
   ]
 }

--- a/token-history.svg
+++ b/token-history.svg
@@ -20,62 +20,69 @@
 <line x1="62" y1="38.0" x2="702" y2="38.0" stroke="#8b949e" stroke-opacity="0.25"/>
 <text x="54" y="41.5" text-anchor="end" font-size="10" fill="#8b949e">18k</text>
 <text x="78.0" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.1.0</text>
-<text x="138.8" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.0</text>
-<text x="199.6" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.1</text>
-<text x="260.4" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.3.0</text>
-<text x="321.2" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.0.0</text>
-<text x="382.0" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.0</text>
-<text x="442.8" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.1</text>
-<text x="503.6" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.2</text>
-<text x="564.4" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.0</text>
-<text x="625.2" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.1</text>
-<text x="686.0" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.3.0</text>
-<polyline points="78.0,113.9 138.8,62.8 199.6,68.3 260.4,53.0 321.2,108.5 382.0,108.2 442.8,108.4 503.6,108.3 564.4,108.3 625.2,106.6 686.0,100.0" fill="none" stroke="#2f81f7" stroke-width="2" stroke-linejoin="round"/>
+<text x="133.3" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.0</text>
+<text x="188.5" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.1</text>
+<text x="243.8" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.3.0</text>
+<text x="299.1" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.0.0</text>
+<text x="354.4" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.0</text>
+<text x="409.6" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.1</text>
+<text x="464.9" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.2</text>
+<text x="520.2" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.0</text>
+<text x="575.5" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.1</text>
+<text x="630.7" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.3.0</text>
+<text x="686.0" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.0</text>
+<polyline points="78.0,113.9 133.3,62.8 188.5,68.3 243.8,53.0 299.1,108.5 354.4,108.2 409.6,108.4 464.9,108.3 520.2,108.3 575.5,106.6 630.7,100.0 686.0,102.9" fill="none" stroke="#2f81f7" stroke-width="2" stroke-linejoin="round"/>
 <circle cx="78.0" cy="113.9" r="3" fill="#2f81f7"/>
-<circle cx="138.8" cy="62.8" r="3" fill="#2f81f7"/>
-<circle cx="199.6" cy="68.3" r="3" fill="#2f81f7"/>
-<circle cx="260.4" cy="53.0" r="3" fill="#2f81f7"/>
-<circle cx="321.2" cy="108.5" r="3" fill="#2f81f7"/>
-<circle cx="382.0" cy="108.2" r="3" fill="#2f81f7"/>
-<circle cx="442.8" cy="108.4" r="3" fill="#2f81f7"/>
-<circle cx="503.6" cy="108.3" r="3" fill="#2f81f7"/>
-<circle cx="564.4" cy="108.3" r="3" fill="#2f81f7"/>
-<circle cx="625.2" cy="106.6" r="3" fill="#2f81f7"/>
-<circle cx="686.0" cy="100.0" r="3" fill="#2f81f7"/>
-<polyline points="260.4,84.6 321.2,130.1 382.0,130.1 442.8,128.7 503.6,128.7 564.4,128.7 625.2,127.0 686.0,120.3" fill="none" stroke="#e3742f" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="260.4" cy="84.6" r="3" fill="#e3742f"/>
-<circle cx="321.2" cy="130.1" r="3" fill="#e3742f"/>
-<circle cx="382.0" cy="130.1" r="3" fill="#e3742f"/>
-<circle cx="442.8" cy="128.7" r="3" fill="#e3742f"/>
-<circle cx="503.6" cy="128.7" r="3" fill="#e3742f"/>
-<circle cx="564.4" cy="128.7" r="3" fill="#e3742f"/>
-<circle cx="625.2" cy="127.0" r="3" fill="#e3742f"/>
-<circle cx="686.0" cy="120.3" r="3" fill="#e3742f"/>
-<polyline points="321.2,193.5 382.0,193.5 442.8,193.5 503.6,193.5 564.4,193.5 625.2,192.4 686.0,192.4" fill="none" stroke="#a371f7" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="321.2" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="382.0" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="442.8" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="503.6" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="564.4" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="625.2" cy="192.4" r="3" fill="#a371f7"/>
+<circle cx="133.3" cy="62.8" r="3" fill="#2f81f7"/>
+<circle cx="188.5" cy="68.3" r="3" fill="#2f81f7"/>
+<circle cx="243.8" cy="53.0" r="3" fill="#2f81f7"/>
+<circle cx="299.1" cy="108.5" r="3" fill="#2f81f7"/>
+<circle cx="354.4" cy="108.2" r="3" fill="#2f81f7"/>
+<circle cx="409.6" cy="108.4" r="3" fill="#2f81f7"/>
+<circle cx="464.9" cy="108.3" r="3" fill="#2f81f7"/>
+<circle cx="520.2" cy="108.3" r="3" fill="#2f81f7"/>
+<circle cx="575.5" cy="106.6" r="3" fill="#2f81f7"/>
+<circle cx="630.7" cy="100.0" r="3" fill="#2f81f7"/>
+<circle cx="686.0" cy="102.9" r="3" fill="#2f81f7"/>
+<polyline points="243.8,84.6 299.1,130.1 354.4,130.1 409.6,128.7 464.9,128.7 520.2,128.7 575.5,127.0 630.7,120.3 686.0,122.1" fill="none" stroke="#e3742f" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="243.8" cy="84.6" r="3" fill="#e3742f"/>
+<circle cx="299.1" cy="130.1" r="3" fill="#e3742f"/>
+<circle cx="354.4" cy="130.1" r="3" fill="#e3742f"/>
+<circle cx="409.6" cy="128.7" r="3" fill="#e3742f"/>
+<circle cx="464.9" cy="128.7" r="3" fill="#e3742f"/>
+<circle cx="520.2" cy="128.7" r="3" fill="#e3742f"/>
+<circle cx="575.5" cy="127.0" r="3" fill="#e3742f"/>
+<circle cx="630.7" cy="120.3" r="3" fill="#e3742f"/>
+<circle cx="686.0" cy="122.1" r="3" fill="#e3742f"/>
+<polyline points="299.1,193.5 354.4,193.5 409.6,193.5 464.9,193.5 520.2,193.5 575.5,192.4 630.7,192.4 686.0,192.4" fill="none" stroke="#a371f7" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="299.1" cy="193.5" r="3" fill="#a371f7"/>
+<circle cx="354.4" cy="193.5" r="3" fill="#a371f7"/>
+<circle cx="409.6" cy="193.5" r="3" fill="#a371f7"/>
+<circle cx="464.9" cy="193.5" r="3" fill="#a371f7"/>
+<circle cx="520.2" cy="193.5" r="3" fill="#a371f7"/>
+<circle cx="575.5" cy="192.4" r="3" fill="#a371f7"/>
+<circle cx="630.7" cy="192.4" r="3" fill="#a371f7"/>
 <circle cx="686.0" cy="192.4" r="3" fill="#a371f7"/>
-<polyline points="382.0,202.6 442.8,202.5 503.6,202.5 564.4,202.5 625.2,201.3 686.0,201.3" fill="none" stroke="#3fb950" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="382.0" cy="202.6" r="3" fill="#3fb950"/>
-<circle cx="442.8" cy="202.5" r="3" fill="#3fb950"/>
-<circle cx="503.6" cy="202.5" r="3" fill="#3fb950"/>
-<circle cx="564.4" cy="202.5" r="3" fill="#3fb950"/>
-<circle cx="625.2" cy="201.3" r="3" fill="#3fb950"/>
+<polyline points="354.4,202.6 409.6,202.5 464.9,202.5 520.2,202.5 575.5,201.3 630.7,201.3 686.0,201.3" fill="none" stroke="#3fb950" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="354.4" cy="202.6" r="3" fill="#3fb950"/>
+<circle cx="409.6" cy="202.5" r="3" fill="#3fb950"/>
+<circle cx="464.9" cy="202.5" r="3" fill="#3fb950"/>
+<circle cx="520.2" cy="202.5" r="3" fill="#3fb950"/>
+<circle cx="575.5" cy="201.3" r="3" fill="#3fb950"/>
+<circle cx="630.7" cy="201.3" r="3" fill="#3fb950"/>
 <circle cx="686.0" cy="201.3" r="3" fill="#3fb950"/>
+<polyline points="630.7,193.7 686.0,193.7" fill="none" stroke="#db61a2" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="630.7" cy="193.7" r="3" fill="#db61a2"/>
 <circle cx="686.0" cy="193.7" r="3" fill="#db61a2"/>
 <circle cx="66" cy="18" r="3.5" fill="#2f81f7"/>
-<text x="75" y="21.5" font-size="11" fill="#8b949e">/open-pr:review 11,655</text>
+<text x="75" y="21.5" font-size="11" fill="#8b949e">/open-pr:review 11,360</text>
 <circle cx="246.0" cy="18" r="3.5" fill="#e3742f"/>
-<text x="255.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:fix 9,585</text>
+<text x="255.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:fix 9,400</text>
 <circle cx="398.0" cy="18" r="3.5" fill="#a371f7"/>
-<text x="407.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:upgrade 2,211</text>
+<text x="407.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:upgrade 2,209</text>
 <circle cx="578.0" cy="18" r="3.5" fill="#3fb950"/>
-<text x="587.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:clean 1,299</text>
+<text x="587.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:clean 1,295</text>
 <circle cx="744.0" cy="18" r="3.5" fill="#db61a2"/>
-<text x="753.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:feedback 2,078</text>
+<text x="753.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:feedback 2,075</text>
 <text x="62" y="252" font-size="9" fill="#8b949e" fill-opacity="0.85">mean per group · cl100k_base proxy · each point frozen at its release · tests/token-history.json</text>
 </svg>


### PR DESCRIPTION
One point per release tag on the context-cost chart, measured at v1.4.0 by `scripts/token_chart.py --add`. The SVG is redrawn from those numbers, never hand-edited — the suite redraws it and compares.