### PR TITLE
chore(manifest): declare 1.4.0, matching the release tag

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "open-pr",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Review pull requests on GitHub, GitLab and Bitbucket across many stacks, learning each repo's own conventions over time and posting one review through that vendor's own CLI or REST API."
 }


### PR DESCRIPTION
v1.4.0 is tagged, so `gemini-extension.json` at 1.3.0 is the stale number `test_the_declared_version_keeps_up_with_the_release_tags` exists to catch — `main` is red on it right now.

Bumps the field to 1.4.0. Suite back to 75 passing.