### PR TITLE
fix(chart): wrap the legend so every line gets a visible entry

### DIFF
--- a/scripts/token_chart.py
+++ b/scripts/token_chart.py
@@ -65,6 +65,7 @@ PR_BODY = (
 W, H = 720, 260
 PAD_L, PAD_R, PAD_T, PAD_B = 62, 18, 38, 46
 GREY = "#8b949e"
+LEGEND_CHAR, LEGEND_DOT, LEGEND_GAP, LEGEND_ROW = 7.0, 13, 13, 17
 
 
 def sh(*args):
@@ -120,13 +121,42 @@ def y_ceiling(values):
     return ((top // step) + 1) * step
 
 
+def legend_rows(points):
+    """Legend entries as rows of (x, colour, text), wrapped so no entry crosses W - PAD_R.
+
+    A command with no released point yet gets no entry: the image is redrawn only when a release
+    adds data, never when code changes. Text width is estimated at LEGEND_CHAR per character,
+    which overshoots the proportional font it is drawn in, so the fit has slack rather than
+    depending on a measurement the script cannot take."""
+    rows, row, lx = [], [], PAD_L
+    for line in LINES:
+        last = next((p[line["key"]] for p in reversed(points) if p.get(line["key"]) is not None), None)
+        if last is None:
+            continue
+        text = f'{line["label"]} {last:,}'
+        span = LEGEND_DOT + LEGEND_CHAR * len(text)
+        if row and lx + span > W - PAD_R:
+            rows.append(row)
+            row, lx = [], PAD_L
+        row.append((lx, line["colour"], text))
+        lx += span + LEGEND_GAP
+    if row:
+        rows.append(row)
+    return rows
+
+
 def render(data):
     points = data["points"]
     if not points:
         raise SystemExit("no points yet — run --add <tag> first")
     values = [v for p in points for v in (p.get(l["key"]) for l in LINES) if v is not None]
     ymax = y_ceiling(values)
-    plot_w, plot_h = W - PAD_L - PAD_R, H - PAD_T - PAD_B
+
+    # every legend row past the first grows the canvas instead of eating into the plot
+    rows = legend_rows(points)
+    extra = (len(rows) - 1) * LEGEND_ROW
+    height, top = H + extra, PAD_T + extra
+    plot_w, plot_h = W - PAD_L - PAD_R, height - top - PAD_B
 
     inset = 16  # keeps the first and last dot off the axis and off the right edge
     span = plot_w - 2 * inset
@@ -137,9 +167,9 @@ def render(data):
         return PAD_L + inset + i * span / (len(points) - 1)
 
     def y(v):
-        return PAD_T + plot_h - (v / ymax) * plot_h
+        return top + plot_h - (v / ymax) * plot_h
 
-    s = [f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}" width="{W}" height="{H}"'
+    s = [f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {height}" width="{W}" height="{height}"'
          f' font-family="system-ui,-apple-system,Segoe UI,Helvetica,Arial,sans-serif"'
          f' role="img" aria-label="Context cost per release, one line per command">']
 
@@ -153,7 +183,7 @@ def render(data):
 
     # x labels
     for i, p in enumerate(points):
-        s.append(f'<text x="{x(i):.1f}" y="{H - PAD_B + 18:.1f}" text-anchor="middle"'
+        s.append(f'<text x="{x(i):.1f}" y="{height - PAD_B + 18:.1f}" text-anchor="middle"'
                  f' font-size="10" fill="{GREY}">{p["tag"]}</text>')
 
     # one polyline + dots per command, skipping the tags where it did not exist
@@ -166,19 +196,16 @@ def render(data):
         for px, py in seq:
             s.append(f'<circle cx="{px:.1f}" cy="{py:.1f}" r="3" fill="{line["colour"]}"/>')
 
-    # legend, and the value each line ends on. A command with no released point yet gets no
-    # legend entry: the image is redrawn only when a release adds data, never when code changes.
-    lx = PAD_L
-    for line in LINES:
-        last = next((p[line["key"]] for p in reversed(points) if p.get(line["key"]) is not None), None)
-        if last is None:
-            continue
-        text = f'{line["label"]} {last:,}'
-        s.append(f'<circle cx="{lx + 4}" cy="{PAD_T - 20}" r="3.5" fill="{line["colour"]}"/>')
-        s.append(f'<text x="{lx + 13}" y="{PAD_T - 16.5}" font-size="11" fill="{GREY}">{text}</text>')
-        lx += 26 + 7.0 * len(text)
+    # legend, and the value each line ends on. The last row keeps its 20px gap above the plot,
+    # so earlier rows stack upward into the space the taller canvas opened.
+    for r, row in enumerate(rows):
+        cy = top - 20 - (len(rows) - 1 - r) * LEGEND_ROW
+        for lx, colour, text in row:
+            s.append(f'<circle cx="{lx + 4}" cy="{cy}" r="3.5" fill="{colour}"/>')
+            s.append(f'<text x="{lx + LEGEND_DOT}" y="{cy + 3.5}" font-size="11"'
+                     f' fill="{GREY}">{text}</text>')
 
-    s.append(f'<text x="{PAD_L}" y="{H - 8}" font-size="9" fill="{GREY}"'
+    s.append(f'<text x="{PAD_L}" y="{height - 8}" font-size="9" fill="{GREY}"'
              f' fill-opacity="0.85">{STAMP}</text>')
     s.append("</svg>")
     SVG.write_text("\n".join(s) + "\n", encoding="utf-8")

--- a/token-history.svg
+++ b/token-history.svg
@@ -1,88 +1,88 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 260" width="720" height="260" font-family="system-ui,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" role="img" aria-label="Context cost per release, one line per command">
-<line x1="62" y1="214.0" x2="702" y2="214.0" stroke="#8b949e" stroke-opacity="0.25"/>
-<text x="54" y="217.5" text-anchor="end" font-size="10" fill="#8b949e">0k</text>
-<line x1="62" y1="194.4" x2="702" y2="194.4" stroke="#8b949e" stroke-opacity="0.25"/>
-<text x="54" y="197.9" text-anchor="end" font-size="10" fill="#8b949e">2k</text>
-<line x1="62" y1="174.9" x2="702" y2="174.9" stroke="#8b949e" stroke-opacity="0.25"/>
-<text x="54" y="178.4" text-anchor="end" font-size="10" fill="#8b949e">4k</text>
-<line x1="62" y1="155.3" x2="702" y2="155.3" stroke="#8b949e" stroke-opacity="0.25"/>
-<text x="54" y="158.8" text-anchor="end" font-size="10" fill="#8b949e">6k</text>
-<line x1="62" y1="135.8" x2="702" y2="135.8" stroke="#8b949e" stroke-opacity="0.25"/>
-<text x="54" y="139.3" text-anchor="end" font-size="10" fill="#8b949e">8k</text>
-<line x1="62" y1="116.2" x2="702" y2="116.2" stroke="#8b949e" stroke-opacity="0.25"/>
-<text x="54" y="119.7" text-anchor="end" font-size="10" fill="#8b949e">10k</text>
-<line x1="62" y1="96.7" x2="702" y2="96.7" stroke="#8b949e" stroke-opacity="0.25"/>
-<text x="54" y="100.2" text-anchor="end" font-size="10" fill="#8b949e">12k</text>
-<line x1="62" y1="77.1" x2="702" y2="77.1" stroke="#8b949e" stroke-opacity="0.25"/>
-<text x="54" y="80.6" text-anchor="end" font-size="10" fill="#8b949e">14k</text>
-<line x1="62" y1="57.6" x2="702" y2="57.6" stroke="#8b949e" stroke-opacity="0.25"/>
-<text x="54" y="61.1" text-anchor="end" font-size="10" fill="#8b949e">16k</text>
-<line x1="62" y1="38.0" x2="702" y2="38.0" stroke="#8b949e" stroke-opacity="0.25"/>
-<text x="54" y="41.5" text-anchor="end" font-size="10" fill="#8b949e">18k</text>
-<text x="78.0" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.1.0</text>
-<text x="133.3" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.0</text>
-<text x="188.5" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.1</text>
-<text x="243.8" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.3.0</text>
-<text x="299.1" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.0.0</text>
-<text x="354.4" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.0</text>
-<text x="409.6" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.1</text>
-<text x="464.9" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.2</text>
-<text x="520.2" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.0</text>
-<text x="575.5" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.1</text>
-<text x="630.7" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.3.0</text>
-<text x="686.0" y="232.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.0</text>
-<polyline points="78.0,113.9 133.3,62.8 188.5,68.3 243.8,53.0 299.1,108.5 354.4,108.2 409.6,108.4 464.9,108.3 520.2,108.3 575.5,106.6 630.7,100.0 686.0,102.9" fill="none" stroke="#2f81f7" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="78.0" cy="113.9" r="3" fill="#2f81f7"/>
-<circle cx="133.3" cy="62.8" r="3" fill="#2f81f7"/>
-<circle cx="188.5" cy="68.3" r="3" fill="#2f81f7"/>
-<circle cx="243.8" cy="53.0" r="3" fill="#2f81f7"/>
-<circle cx="299.1" cy="108.5" r="3" fill="#2f81f7"/>
-<circle cx="354.4" cy="108.2" r="3" fill="#2f81f7"/>
-<circle cx="409.6" cy="108.4" r="3" fill="#2f81f7"/>
-<circle cx="464.9" cy="108.3" r="3" fill="#2f81f7"/>
-<circle cx="520.2" cy="108.3" r="3" fill="#2f81f7"/>
-<circle cx="575.5" cy="106.6" r="3" fill="#2f81f7"/>
-<circle cx="630.7" cy="100.0" r="3" fill="#2f81f7"/>
-<circle cx="686.0" cy="102.9" r="3" fill="#2f81f7"/>
-<polyline points="243.8,84.6 299.1,130.1 354.4,130.1 409.6,128.7 464.9,128.7 520.2,128.7 575.5,127.0 630.7,120.3 686.0,122.1" fill="none" stroke="#e3742f" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="243.8" cy="84.6" r="3" fill="#e3742f"/>
-<circle cx="299.1" cy="130.1" r="3" fill="#e3742f"/>
-<circle cx="354.4" cy="130.1" r="3" fill="#e3742f"/>
-<circle cx="409.6" cy="128.7" r="3" fill="#e3742f"/>
-<circle cx="464.9" cy="128.7" r="3" fill="#e3742f"/>
-<circle cx="520.2" cy="128.7" r="3" fill="#e3742f"/>
-<circle cx="575.5" cy="127.0" r="3" fill="#e3742f"/>
-<circle cx="630.7" cy="120.3" r="3" fill="#e3742f"/>
-<circle cx="686.0" cy="122.1" r="3" fill="#e3742f"/>
-<polyline points="299.1,193.5 354.4,193.5 409.6,193.5 464.9,193.5 520.2,193.5 575.5,192.4 630.7,192.4 686.0,192.4" fill="none" stroke="#a371f7" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="299.1" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="354.4" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="409.6" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="464.9" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="520.2" cy="193.5" r="3" fill="#a371f7"/>
-<circle cx="575.5" cy="192.4" r="3" fill="#a371f7"/>
-<circle cx="630.7" cy="192.4" r="3" fill="#a371f7"/>
-<circle cx="686.0" cy="192.4" r="3" fill="#a371f7"/>
-<polyline points="354.4,202.6 409.6,202.5 464.9,202.5 520.2,202.5 575.5,201.3 630.7,201.3 686.0,201.3" fill="none" stroke="#3fb950" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="354.4" cy="202.6" r="3" fill="#3fb950"/>
-<circle cx="409.6" cy="202.5" r="3" fill="#3fb950"/>
-<circle cx="464.9" cy="202.5" r="3" fill="#3fb950"/>
-<circle cx="520.2" cy="202.5" r="3" fill="#3fb950"/>
-<circle cx="575.5" cy="201.3" r="3" fill="#3fb950"/>
-<circle cx="630.7" cy="201.3" r="3" fill="#3fb950"/>
-<circle cx="686.0" cy="201.3" r="3" fill="#3fb950"/>
-<polyline points="630.7,193.7 686.0,193.7" fill="none" stroke="#db61a2" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="630.7" cy="193.7" r="3" fill="#db61a2"/>
-<circle cx="686.0" cy="193.7" r="3" fill="#db61a2"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 277" width="720" height="277" font-family="system-ui,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" role="img" aria-label="Context cost per release, one line per command">
+<line x1="62" y1="231.0" x2="702" y2="231.0" stroke="#8b949e" stroke-opacity="0.25"/>
+<text x="54" y="234.5" text-anchor="end" font-size="10" fill="#8b949e">0k</text>
+<line x1="62" y1="211.4" x2="702" y2="211.4" stroke="#8b949e" stroke-opacity="0.25"/>
+<text x="54" y="214.9" text-anchor="end" font-size="10" fill="#8b949e">2k</text>
+<line x1="62" y1="191.9" x2="702" y2="191.9" stroke="#8b949e" stroke-opacity="0.25"/>
+<text x="54" y="195.4" text-anchor="end" font-size="10" fill="#8b949e">4k</text>
+<line x1="62" y1="172.3" x2="702" y2="172.3" stroke="#8b949e" stroke-opacity="0.25"/>
+<text x="54" y="175.8" text-anchor="end" font-size="10" fill="#8b949e">6k</text>
+<line x1="62" y1="152.8" x2="702" y2="152.8" stroke="#8b949e" stroke-opacity="0.25"/>
+<text x="54" y="156.3" text-anchor="end" font-size="10" fill="#8b949e">8k</text>
+<line x1="62" y1="133.2" x2="702" y2="133.2" stroke="#8b949e" stroke-opacity="0.25"/>
+<text x="54" y="136.7" text-anchor="end" font-size="10" fill="#8b949e">10k</text>
+<line x1="62" y1="113.7" x2="702" y2="113.7" stroke="#8b949e" stroke-opacity="0.25"/>
+<text x="54" y="117.2" text-anchor="end" font-size="10" fill="#8b949e">12k</text>
+<line x1="62" y1="94.1" x2="702" y2="94.1" stroke="#8b949e" stroke-opacity="0.25"/>
+<text x="54" y="97.6" text-anchor="end" font-size="10" fill="#8b949e">14k</text>
+<line x1="62" y1="74.6" x2="702" y2="74.6" stroke="#8b949e" stroke-opacity="0.25"/>
+<text x="54" y="78.1" text-anchor="end" font-size="10" fill="#8b949e">16k</text>
+<line x1="62" y1="55.0" x2="702" y2="55.0" stroke="#8b949e" stroke-opacity="0.25"/>
+<text x="54" y="58.5" text-anchor="end" font-size="10" fill="#8b949e">18k</text>
+<text x="78.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.1.0</text>
+<text x="133.3" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.0</text>
+<text x="188.5" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.1</text>
+<text x="243.8" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.3.0</text>
+<text x="299.1" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.0.0</text>
+<text x="354.4" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.0</text>
+<text x="409.6" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.1</text>
+<text x="464.9" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.2</text>
+<text x="520.2" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.0</text>
+<text x="575.5" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.1</text>
+<text x="630.7" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.3.0</text>
+<text x="686.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.0</text>
+<polyline points="78.0,130.9 133.3,79.8 188.5,85.3 243.8,70.0 299.1,125.5 354.4,125.2 409.6,125.4 464.9,125.3 520.2,125.3 575.5,123.6 630.7,117.0 686.0,119.9" fill="none" stroke="#2f81f7" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="78.0" cy="130.9" r="3" fill="#2f81f7"/>
+<circle cx="133.3" cy="79.8" r="3" fill="#2f81f7"/>
+<circle cx="188.5" cy="85.3" r="3" fill="#2f81f7"/>
+<circle cx="243.8" cy="70.0" r="3" fill="#2f81f7"/>
+<circle cx="299.1" cy="125.5" r="3" fill="#2f81f7"/>
+<circle cx="354.4" cy="125.2" r="3" fill="#2f81f7"/>
+<circle cx="409.6" cy="125.4" r="3" fill="#2f81f7"/>
+<circle cx="464.9" cy="125.3" r="3" fill="#2f81f7"/>
+<circle cx="520.2" cy="125.3" r="3" fill="#2f81f7"/>
+<circle cx="575.5" cy="123.6" r="3" fill="#2f81f7"/>
+<circle cx="630.7" cy="117.0" r="3" fill="#2f81f7"/>
+<circle cx="686.0" cy="119.9" r="3" fill="#2f81f7"/>
+<polyline points="243.8,101.6 299.1,147.1 354.4,147.1 409.6,145.7 464.9,145.7 520.2,145.7 575.5,144.0 630.7,137.3 686.0,139.1" fill="none" stroke="#e3742f" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="243.8" cy="101.6" r="3" fill="#e3742f"/>
+<circle cx="299.1" cy="147.1" r="3" fill="#e3742f"/>
+<circle cx="354.4" cy="147.1" r="3" fill="#e3742f"/>
+<circle cx="409.6" cy="145.7" r="3" fill="#e3742f"/>
+<circle cx="464.9" cy="145.7" r="3" fill="#e3742f"/>
+<circle cx="520.2" cy="145.7" r="3" fill="#e3742f"/>
+<circle cx="575.5" cy="144.0" r="3" fill="#e3742f"/>
+<circle cx="630.7" cy="137.3" r="3" fill="#e3742f"/>
+<circle cx="686.0" cy="139.1" r="3" fill="#e3742f"/>
+<polyline points="299.1,210.5 354.4,210.5 409.6,210.5 464.9,210.5 520.2,210.5 575.5,209.4 630.7,209.4 686.0,209.4" fill="none" stroke="#a371f7" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="299.1" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="354.4" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="409.6" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="464.9" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="520.2" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="575.5" cy="209.4" r="3" fill="#a371f7"/>
+<circle cx="630.7" cy="209.4" r="3" fill="#a371f7"/>
+<circle cx="686.0" cy="209.4" r="3" fill="#a371f7"/>
+<polyline points="354.4,219.6 409.6,219.5 464.9,219.5 520.2,219.5 575.5,218.3 630.7,218.3 686.0,218.3" fill="none" stroke="#3fb950" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="354.4" cy="219.6" r="3" fill="#3fb950"/>
+<circle cx="409.6" cy="219.5" r="3" fill="#3fb950"/>
+<circle cx="464.9" cy="219.5" r="3" fill="#3fb950"/>
+<circle cx="520.2" cy="219.5" r="3" fill="#3fb950"/>
+<circle cx="575.5" cy="218.3" r="3" fill="#3fb950"/>
+<circle cx="630.7" cy="218.3" r="3" fill="#3fb950"/>
+<circle cx="686.0" cy="218.3" r="3" fill="#3fb950"/>
+<polyline points="630.7,210.7 686.0,210.7" fill="none" stroke="#db61a2" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="630.7" cy="210.7" r="3" fill="#db61a2"/>
+<circle cx="686.0" cy="210.7" r="3" fill="#db61a2"/>
 <circle cx="66" cy="18" r="3.5" fill="#2f81f7"/>
 <text x="75" y="21.5" font-size="11" fill="#8b949e">/open-pr:review 11,360</text>
 <circle cx="246.0" cy="18" r="3.5" fill="#e3742f"/>
 <text x="255.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:fix 9,400</text>
 <circle cx="398.0" cy="18" r="3.5" fill="#a371f7"/>
 <text x="407.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:upgrade 2,209</text>
-<circle cx="578.0" cy="18" r="3.5" fill="#3fb950"/>
-<text x="587.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:clean 1,295</text>
-<circle cx="744.0" cy="18" r="3.5" fill="#db61a2"/>
-<text x="753.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:feedback 2,075</text>
-<text x="62" y="252" font-size="9" fill="#8b949e" fill-opacity="0.85">mean per group · cl100k_base proxy · each point frozen at its release · tests/token-history.json</text>
+<circle cx="66" cy="35" r="3.5" fill="#3fb950"/>
+<text x="75" y="38.5" font-size="11" fill="#8b949e">/open-pr:clean 1,295</text>
+<circle cx="232.0" cy="35" r="3.5" fill="#db61a2"/>
+<text x="241.0" y="38.5" font-size="11" fill="#8b949e">/open-pr:feedback 2,075</text>
+<text x="62" y="269" font-size="9" fill="#8b949e" fill-opacity="0.85">mean per group · cl100k_base proxy · each point frozen at its release · tests/token-history.json</text>
 </svg>


### PR DESCRIPTION
## Description

The chart draws 5 lines but the legend laid them all on one row, accumulating `x` with no check
against `W - PAD_R`. `/open-pr:feedback` landed at `x=753` on a 720-wide canvas — entirely
off-image since it got its first point at v1.3.0 — and `/open-pr:clean` clipped at the edge.

Entries now wrap onto a new row when the next would cross the right edge, and each row past the
first grows the canvas instead of the plot, so the plot keeps its 176px height. The wrap is
driven by the entry widths, so a 6th command cannot reintroduce the clip.

`token-history.svg` is regenerated by `scripts/token_chart.py --render` — no data point added,
`tests/token-history.json` untouched.

## Type of change

- [ ] 🔴 Breaking change (changes config/output behavior that repos using the plugin depend on)
- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] 📝 Docs (README/CLAUDE.md, no runtime behavior change)
- [ ] 🔧 Chore (refactor, tooling, no user-visible behavior change)

## How was this tested

`scripts/check.sh main` passes: 74 tests, duplication scan clean, context cost +0.0% on every
scenario (no `src/` file changed). `test_token_history_is_frozen_and_its_chart_matches` redraws
the SVG from the stored numbers and compares, so it locks this layout.

`test_the_declared_version_keeps_up_with_the_release_tags` fails on `main` too — #53 bumps
`gemini-extension.json` and is not merged yet. Not from this branch.

Geometry checked by computing each legend entry's x-extent from the emitted SVG and asserting it
stays inside the canvas, plus the same assertion with 1 to 4 synthetic extra commands. Rendered
extents confirm the fit: the widest entry ends at x=533 against a 702 limit.

## Checklist

- [x] `scripts/check.sh <base-ref>` passes — suite, duplication scan, context cost
- [x] Context cost: unchanged — this touches no `src/` file
- [ ] `tests/token-history.json` and `token-history.svg` untouched — the chart takes one frozen
  point per release (`/release-now`), never one per PR
  <!-- token-history.svg is regenerated here on purpose: this is the layout fix, not a new point.
       tests/token-history.json is untouched. -->
- [x] Behavior/architecture change → updated `CLAUDE.md` accordingly — n/a, no rule changed
- [x] Anything a user sees → every README version and the owning `docs/` page — n/a, the image the
  READMEs already embed is the thing being fixed; no text changed
- [x] Added a config field — n/a
- [x] Changed the config shape an EXISTING repo already has — n/a
- [x] No new `allowed-tools` grant is broader than necessary — n/a
