### PR TITLE
fix(review): gate the submodule tree against the submodule PR's head

### DIFF
--- a/src/cases/submodule-review.md
+++ b/src/cases/submodule-review.md
@@ -81,8 +81,8 @@ Step 6 for this pass uses the SUBMODULE PR's own comments from Step D, not the m
 Exactly 1 composite result, via the same `V§"Post a review"` → `V§"Verify a posted review's state"` →
 `V§"Publish the pending review"` flow and the same invariants as `review.md` Step 9, with 2 differences:
 
-- `<commit_id>` = `V§"Fetch PR head commit SHA"` for the SUBMODULE PR, re-fetched right before posting
-  (same staleness reasoning as Step 9) — never Step D's value, never the main PR's.
+- `<commit_id>` = what Step E's Step 8 pass resolved for the SUBMODULE PR, by that Step's own rule
+  against Step D's "Head SHA" — never the main PR's, never re-fetched here.
 - `auto_submit_review`/`auto_resolve_fixed_findings` come from the MAIN repo's `.review` node, already
   read at `review.md` Step 3 — never asked again; submodules have no separate config.
 

--- a/src/cases/submodule-review.md
+++ b/src/cases/submodule-review.md
@@ -61,6 +61,11 @@ Re-run `review.md`'s Context fetch table against the submodule PR — same order
 
 ## Step E — Fully review the submodule PR
 
+`git -C "<worktree>/<submodule-path>" rev-parse HEAD` MUST prefix-match Step D's "Head SHA" BEFORE
+anything below — `review.md` Step 1's head-SHA gate, its single retry included, re-running Step C in
+place of that Step's checkout. Still mismatched ⇒ SKIP Step E + Step F, print both SHAs +
+`<submodule-path>`, state this submodule was left unreviewed, MAIN PR's review continues unblocked.
+
 Reapply `review.md` Step 2 → Step 8 against the Step D data, with exactly 2 differences:
 
 - its own stack detection over the submodule's diff files, independent of the main PR's

--- a/src/cases/submodule-review.md
+++ b/src/cases/submodule-review.md
@@ -66,16 +66,21 @@ anything below — `review.md` Step 1's head-SHA gate, its single retry re-runni
 mismatched ⇒ SKIP Step E + Step F, report both SHAs + `<submodule-path>` as left unreviewed, MAIN
 PR's review continues unblocked.
 
-Reapply `review.md` Step 2 → Step 8 against the Step D data, with exactly 2 differences:
+Reapply `review.md` Step 2 → Step 8 against the Step D data, with exactly 3 differences:
 
+- every tree access aims at the SUBMODULE's checkout: `<worktree>/<submodule-path>/<path>` for each
+  `<worktree>/<path>` those Steps name, `git -C "<worktree>/<submodule-path>"` for each `git -C
+  "<worktree>"` — Step 7's reads, Step 6's check of an old finding against current code, and the line
+  confirmation Step F inherits from `review.md` Step 9, its merge base included. FORBIDDEN: the MAIN
+  repo's tree, which holds a different file at the same path.
 - its own stack detection over the submodule's diff files, independent of the main PR's
 - memory/templates SHARE the MAIN repo's directory, `notebooks/review/<repo>/` (`<repo>` = from the
   ORIGINAL PR URL). FORBIDDEN: a separate `notebooks/review/<repo-submodule>/` — bootstrap, doctor and
   `.review` exist once, for the main repo. A submodule stack missing from `templates_copied` still gets
   its template copied/authored as usual, into that same directory.
 
-Step 6 for this pass uses the SUBMODULE PR's own comments from Step D, not the main PR's, and its
-early-stop gate's `Step 8/9` = this pass's Step 8 + Step F.
+Step 6 for this pass uses the SUBMODULE PR's own comments from Step D, not the main PR's;
+`re-review.md`'s early-stop gate reads `Step 8/9` as this pass's Step 8 + Step F.
 
 ## Step F — Post the submodule PR's result
 

--- a/src/cases/submodule-review.md
+++ b/src/cases/submodule-review.md
@@ -62,9 +62,9 @@ Re-run `review.md`'s Context fetch table against the submodule PR — same order
 ## Step E — Fully review the submodule PR
 
 `git -C "<worktree>/<submodule-path>" rev-parse HEAD` MUST prefix-match Step D's "Head SHA" BEFORE
-anything below — `review.md` Step 1's head-SHA gate, its single retry included, re-running Step C in
-place of that Step's checkout. Still mismatched ⇒ SKIP Step E + Step F, print both SHAs +
-`<submodule-path>`, state this submodule was left unreviewed, MAIN PR's review continues unblocked.
+anything below — `review.md` Step 1's head-SHA gate, its single retry re-running Step C. Still
+mismatched ⇒ SKIP Step E + Step F, report both SHAs + `<submodule-path>` as left unreviewed, MAIN
+PR's review continues unblocked.
 
 Reapply `review.md` Step 2 → Step 8 against the Step D data, with exactly 2 differences:
 
@@ -74,7 +74,8 @@ Reapply `review.md` Step 2 → Step 8 against the Step D data, with exactly 2 di
   `.review` exist once, for the main repo. A submodule stack missing from `templates_copied` still gets
   its template copied/authored as usual, into that same directory.
 
-Step 6 for this pass uses the SUBMODULE PR's own comments from Step D, not the main PR's.
+Step 6 for this pass uses the SUBMODULE PR's own comments from Step D, not the main PR's, and its
+early-stop gate's `Step 8/9` = this pass's Step 8 + Step F.
 
 ## Step F — Post the submodule PR's result
 

--- a/tests/budgets.json
+++ b/tests/budgets.json
@@ -4,7 +4,7 @@
     "review/known-repo-github-clean": 10474,
     "review/known-repo-gitlab-rereview": 14396,
     "review/large-diff-multistack": 12339,
-    "review/submodule-bump": 12279,
+    "review/submodule-bump": 12522,
     "review/agent-instructions-repo": 11179,
     "review/post-error-github": 10883,
     "chat/reconfigure-review": 8000,

--- a/tests/test_prompt_graph.py
+++ b/tests/test_prompt_graph.py
@@ -896,6 +896,24 @@ def test_submodules_are_checked_out_only_when_bumped():
         "the worktree sits beside the project repo; a submodule holds no memory directory"
 
 
+def test_every_reviewed_tree_is_gated_against_its_own_head_sha():
+    """A tree on disk can be one the PR does not describe: the checkout errored, or the ref still
+    served the previous commit. Findings read there would be reported against the PR's real head,
+    so every tree a review reads is compared to the head SHA fetched for THAT PR before any
+    finding is written — the main worktree and a submodule's subdirectory alike."""
+    for f, tree in (
+        (SRC / "commands" / "review.md", '"<worktree>"'),
+        (SRC / "cases" / "submodule-review.md", '"<worktree>/<submodule-path>"'),
+    ):
+        flat = " ".join(text(f).split())
+        assert f"git -C {tree} rev-parse HEAD` MUST prefix-match" in flat, \
+            f"{f.name} must compare {tree} to the head SHA it fetched for that PR"
+
+    sub = " ".join(text(SRC / "cases" / "submodule-review.md").split())
+    assert "SKIP Step E + Step F" in sub and "MAIN PR's review continues unblocked" in sub, \
+        "a submodule tree that stays mismatched drops its own pass, never the main PR's review"
+
+
 def test_clean_deletes_worktrees_and_nothing_else():
     """This is the only command whose job is `rm`, standing in a directory that also holds the
     one thing here nobody can regenerate: what the repo taught it. A worktree comes back on the

--- a/tests/test_prompt_graph.py
+++ b/tests/test_prompt_graph.py
@@ -914,6 +914,25 @@ def test_every_reviewed_tree_is_gated_against_its_own_head_sha():
         "a submodule tree that stays mismatched drops its own pass, never the main PR's review"
 
 
+def test_the_submodule_pass_reads_its_own_tree():
+    """The reapplied Steps name `<worktree>/<path>` and `git -C "<worktree>"` — the PARENT repo, where
+    the same path holds a different file. A submodule pass reading there would confirm line numbers and
+    compare old findings against code from another repository, so its differences list carries the
+    redirect, and the count that list states has to match what it holds."""
+    sub = text(SRC / "cases" / "submodule-review.md")
+    flat = " ".join(sub.split())
+    assert "<worktree>/<submodule-path>/<path>" in flat, \
+        "the submodule pass must name its own read root"
+    assert 'git -C "<worktree>/<submodule-path>"' in flat, \
+        "a git call in the submodule pass must be aimed at the submodule's checkout"
+
+    m = re.search(r"with exactly (\d+) differences:\n\n(.*?)\n\n", sub, re.S)
+    assert m, "the reapply instruction must state how many differences it lists"
+    listed = len(re.findall(r"^- ", m.group(2), re.M))
+    assert int(m.group(1)) == listed, \
+        f"the list says {m.group(1)} differences and holds {listed}"
+
+
 def test_clean_deletes_worktrees_and_nothing_else():
     """This is the only command whose job is `rm`, standing in a directory that also holds the
     one thing here nobody can regenerate: what the repo taught it. A worktree comes back on the


### PR DESCRIPTION
Closes #69

## What was wrong

A submodule review could run against a tree the submodule PR does not describe, with nothing detecting it.

`review.md` Step 1 gates the main worktree: `git -C "<worktree>" rev-parse HEAD` must prefix-match the head SHA fetched for that PR, and the run stops when it still mismatches after one retry. `src/cases/submodule-review.md` had no counterpart. Step C checks the submodule PR out into `<worktree>/<submodule-path>`, and Step E jumps straight to "Reapply `review.md` Step 2 → Step 8" — Step 1 is excluded, so no step read that subdirectory's HEAD.

When that checkout fails, the subdirectory keeps what Step A's init left there: the SHA the parent PR bumps to. That often equals the submodule PR's head, which is why the gap did not always show. Where the bump points at a different commit, the whole submodule pass read one tree and reported against another.

A second contradiction sat in Step F: it resolved `<commit_id>` with its own re-fetch and forbade Step D's value, while `review.md` Step 8 — which Step E already runs — requires exactly that value when the head moved mid-review, and forbids the freshly fetched SHA because no finding describes that tree. Its cross-reference also named Step 9 rather than the Step that owns the resolution.

## What this PR changes

- Step E opens with the gate, before anything else, carrying over Step 1's rule and its single retry: a ref still serving the previous commit resolves on the 2nd fetch, an errored checkout does not.
- A second mismatch skips Step E and Step F for that submodule and says so. The main PR's review continues — its own worktree already passed Step 1's gate, so it still reads the code it reports on, and the dev can review the submodule PR directly by URL. This matches how Step B's remote mismatch already behaves.
- Step F takes the `<commit_id>` that Step E's Step 8 pass produced, leaving one owner for the rule.

The gate belongs at the top of Step E rather than in Step C because the submodule PR's head SHA is not fetched until Step D.

## Result

`test_every_reviewed_tree_is_gated_against_its_own_head_sha` covers both trees — the main worktree and the submodule subdirectory — plus the skip semantics. It fails on `submodule-review.md` as it stood before this branch; nothing in the suite asserted this rule, which is how the submodule path lost the gate silently.

`scripts/check.sh release/pending-review-fixes`: 77 passed, duplication scan clean.

## Context cost

`review/submodule-bump` +110 to 12,158, against a ceiling of 12,241 — 83 of slack left, no ceiling change needed. Mean +13. Two rounds of cutting first: the rationale for why a failed checkout leaves the bumped SHA behind, and a `FORBIDDEN` clause that restated what `SKIP Step E` already says.

## Follow-up in this PR

`re-review.md`'s early-stop gate drops "Step 8/9" when a round has nothing new. Step E reapplies Step 8, so the drop reached the composing step, but no file said which step plays Step 9's part for a submodule — leaving Step F free to post a result no Step composed. Step E now names the pair the gate covers.

Rebased onto `96e1f53`. Re-measured after that: `review/submodule-bump` +112 to 12,209 against the 12,241 ceiling, 32 of slack left. 77 passed, duplication scan clean.

## The submodule pass read the parent repo

Found while checking that the re-review path still holds. `review.md`'s Steps name `<worktree>/<path>` and `git -C "<worktree>"`, and Step E reapplied them with a differences list stating that only stack detection and the memory directory differ. Nothing redirected the reads, so a submodule pass could judge findings against the parent's files at the same path, confirm line numbers on the wrong file, resolve a merge base in the wrong repository, and compare an old finding to code from another project.

Unlike the gate above, this one does not need a failure to trigger — it is the normal path.

The redirect is now the first entry in that list, naming the three places those Steps reach a tree. `test_the_submodule_pass_reads_its_own_tree` asserts the read root, the git target, and that the list's stated count matches what it holds — the count is what tells the reapplying Step nothing else changes, so a bullet added without it is the same defect returning.

`review/submodule-bump` +243 to 12,340; its ceiling is raised by the same delta, 12,279 to 12,522, keeping the slack it had. It is the only scenario reading this file. 78 passed, duplication scan clean.
