### PR TITLE
fix(install): ask the platform once, and let an install follow a branch

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -30,6 +30,16 @@ curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/instal
 
 After you reload the plugin, if the new build changes the **schema** a lot, run `/open-pr:upgrade` to bring that repo's settings up to date.
 
+## Install a branch
+
+Installs any branch or tag instead of the newest release. `--update` then stays on it.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/install.sh | bash -s -- --ref <branch-or-tag>
+```
+
+`--ref latest` goes back to the newest release.
+
 ## Uninstall
 
 ```bash

--- a/docs/ja-JP/install.md
+++ b/docs/ja-JP/install.md
@@ -30,6 +30,16 @@ curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/instal
 
 プラグインを reload したあと、新しいビルドで **schema** が大きく変わっていれば `/open-pr:upgrade` でそのリポジトリの settings を更新します。
 
+## Install a branch
+
+最新リリースの代わりに、任意の branch または tag を入れます。以降の `--update` もそこに留まります。
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/install.sh | bash -s -- --ref <branch-or-tag>
+```
+
+`--ref latest` で最新リリースに戻します。
+
 ## Uninstall
 
 ```bash

--- a/docs/vi-VN/install.md
+++ b/docs/vi-VN/install.md
@@ -30,6 +30,16 @@ curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/instal
 
 Sau khi reload plugin, nếu bản mới đổi nhiều **schema** thì chạy `/open-pr:upgrade` để cập nhật settings của repo.
 
+## Install a branch
+
+Cài một branch hoặc tag bất kỳ thay cho release mới nhất. `--update` sau đó vẫn ở trên nó.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/install.sh | bash -s -- --ref <branch-or-tag>
+```
+
+`--ref latest` để về lại release mới nhất.
+
 ## Uninstall
 
 ```bash

--- a/docs/zh-Hans/install.md
+++ b/docs/zh-Hans/install.md
@@ -30,6 +30,16 @@ curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/instal
 
 重新加载插件之后，如果新版本对 **schema** 改动较大，运行 `/open-pr:upgrade` 把该仓库的设置更新到最新。
 
+## 安装某个分支
+
+安装任意分支或 tag，而不是最新发布版。之后的 `--update` 也留在上面。
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/install.sh | bash -s -- --ref <branch-or-tag>
+```
+
+`--ref latest` 回到最新发布版。
+
 ## 卸载
 
 ```bash

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "open-pr",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Review pull requests on GitHub, GitLab and Bitbucket across many stacks, learning each repo's own conventions over time and posting one review through that vendor's own CLI or REST API."
 }

--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,11 @@
 # scripts/install-local.sh, which is what actually installs and is the only place that knows a
 # platform's directories. Read it there afterwards; it is the code that ran.
 #
-# Env: OPEN_PR_HOME (default ~/.open-pr) · OPEN_PR_REF (default: latest release tag; `main` for the
-# development branch) · OPEN_PR_REPO (default: this project on GitHub).
+# Args: --ref <branch-or-tag> installs that ref instead of the newest release, and every later run
+# stays on it; `--ref latest` returns to releases. Everything else is passed to install-local.sh.
+#
+# Env: OPEN_PR_HOME (default ~/.open-pr) · OPEN_PR_REF (same as --ref) · OPEN_PR_REPO (default: this
+# project on GitHub).
 #
 # Claude Code can also install without any of this: `/plugin marketplace add TOMOSIA-VIETNAM/open-pr`.
 #
@@ -42,17 +45,44 @@ is_our_clone() {
 main() {
   local repo="${OPEN_PR_REPO:-https://github.com/TOMOSIA-VIETNAM/open-pr}"
   local home="${OPEN_PR_HOME:-$HOME/.open-pr}"
-  local ref="${OPEN_PR_REF:-}"
-  local uninstalling=no targeted=no arg tmp=
+  # `ref` is what to check out; `pinned` is what the clone should follow from now on — empty means
+  # the release channel. `named=no` means this run said nothing about the ref, and then an existing
+  # clone keeps following whatever it already followed.
+  local ref="${OPEN_PR_REF:-}" pinned="${OPEN_PR_REF:-}" named=no
+  [ -z "$ref" ] || named=yes
+  local uninstalling=no targeted=no tmp=
+  # What install-local.sh gets: its own flags, none of ours.
+  local -a pass=()
 
-  for arg in "$@"; do
-    case "$arg" in
-      --uninstall) uninstalling=yes ;;
-      --platform|--all|--target) targeted=yes ;;
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --uninstall) uninstalling=yes; pass+=("$1"); shift ;;
+      --platform|--all|--target) targeted=yes; pass+=("$1"); shift ;;
+      --ref) [ $# -ge 2 ] && [ -n "$2" ] || {
+               printf 'install.sh: --ref needs a branch or tag name, or `latest`\n' >&2; exit 2; }
+             ref="$2"; pinned="$2"; named=yes; shift 2 ;;
+      --ref=?*) ref="${1#--ref=}"; pinned="$ref"; named=yes; shift ;;
+      --ref=) printf 'install.sh: --ref needs a branch or tag name, or `latest`\n' >&2; exit 2 ;;
+      # The clone below is already moved onto the wanted ref before install-local.sh runs. Passing
+      # --update on would have it fetch a second time and re-exec itself, and that second run is
+      # what asked the platform question twice.
+      --update) shift ;;
+      *) pass+=("$1"); shift ;;
     esac
   done
 
   command -v git >/dev/null || { printf 'install.sh: git is required\n' >&2; exit 1; }
+
+  # `latest` is the way back from a branch to the release channel: it asks for a release and for
+  # nothing to be followed afterwards.
+  if [ "$ref" = latest ]; then ref=; pinned=; fi
+
+  # A clone already following a ref stays on it, so re-running the one-liner to update does not drop
+  # someone off the branch they installed on purpose.
+  if [ "$named" = no ] && [ -d "$home/.git" ] && is_our_clone "$home" "$repo"; then
+    ref="$(git -C "$home" config --get open-pr.ref 2>/dev/null || true)"
+    pinned="$ref"
+  fi
 
   if [ -z "$ref" ]; then
     # Highest release tag, so a one-liner never lands on an unreleased commit.
@@ -86,13 +116,13 @@ main() {
     fi
     [ -x "$runner" ] || {
       printf 'install.sh: no uninstaller in %s at %s. Name a ref that has one:\n' "$repo" "$ref" >&2
-      printf '  OPEN_PR_REF=<branch-or-tag> before this command, or see docs/install.md\n' >&2
+      printf '  --ref <branch-or-tag> after this command, or see docs/install.md\n' >&2
       [ -z "$tmp" ] || rm -rf "$tmp"
       exit 1; }
     # `set -e` would exit here on a non-zero uninstall, before the borrowed clone is cleaned up and
     # before anything is said about what failed.
     local rc=0
-    "$runner" "$@" || rc=$?
+    "$runner" ${pass+"${pass[@]}"} || rc=$?
     [ -z "$tmp" ] || rm -rf "$tmp"
     # A run that named no platform meant all of it, so the clone goes too. One that named a platform
     # leaves the rest installed, and they need this clone to keep working.
@@ -145,9 +175,19 @@ main() {
       printf 'install.sh: %s/scripts/install-local.sh is missing\n' "$home" >&2; exit 1; }
   fi
 
+  # What this clone follows from now on, kept in its own config so a checkout cannot lose it and
+  # nothing tracked has to carry it. Read back here and by install-local.sh --update. Following the
+  # release channel is the absence of a value, so `--ref latest` clears it.
+  if [ -n "$pinned" ]; then
+    git -C "$home" config open-pr.ref "$pinned"
+    say 'following %s — `--ref latest` returns to releases\n' "$pinned"
+  else
+    git -C "$home" config --unset open-pr.ref 2>/dev/null || true
+  fi
+
   say '\nInstalled the plugin files. Next, the platform you run it on.\n'
   say 'Read what does the rest: %s/scripts/install-local.sh\n\n' "$home"
-  exec "$home/scripts/install-local.sh" "$@"
+  exec "$home/scripts/install-local.sh" ${pass+"${pass[@]}"}
 }
 
 main "$@"

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,8 @@
 # platform's directories. Read it there afterwards; it is the code that ran.
 #
 # Args: --ref <branch-or-tag> installs that ref instead of the newest release, and every later run
-# stays on it; `--ref latest` returns to releases. Everything else is passed to install-local.sh.
+# stays on it; `--ref latest` returns to releases. `--update` stops here; everything else is
+# passed to install-local.sh.
 #
 # Env: OPEN_PR_HOME (default ~/.open-pr) · OPEN_PR_REF (same as --ref) · OPEN_PR_REPO (default: this
 # project on GitHub).
@@ -64,8 +65,8 @@ main() {
       --ref=?*) ref="${1#--ref=}"; pinned="$ref"; named=yes; shift ;;
       --ref=) printf 'install.sh: --ref needs a branch or tag name, or `latest`\n' >&2; exit 2 ;;
       # The clone below is already moved onto the wanted ref before install-local.sh runs. Passing
-      # --update on would have it fetch a second time and re-exec itself, and that second run is
-      # what asked the platform question twice.
+      # --update on makes it fetch a second time and re-exec itself, and that second run asks the
+      # platform question again.
       --update) shift ;;
       *) pass+=("$1"); shift ;;
     esac

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -106,6 +106,8 @@ while [ $# -gt 0 ]; do
     --ref) [ $# -ge 2 ] && [ -n "$2" ] || {
              printf 'install-local.sh: --ref needs a branch or tag name, or `latest`\n' >&2; exit 2; }
            REF="$2"; shift 2 ;;
+    --ref=?*) REF="${1#--ref=}"; shift ;;
+    --ref=) printf 'install-local.sh: --ref needs a branch or tag name, or `latest`\n' >&2; exit 2 ;;
     -h|--help) usage; exit 0 ;;
     *) printf 'install-local.sh: unexpected argument %s\n' "$1" >&2; usage >&2; exit 2 ;;
   esac
@@ -165,6 +167,7 @@ if [ "$ACTION" = update ]; then
     case "$arg" in
       --update) ;;
       --ref) drop_value=yes ;;
+      --ref=*) ;;
       *) rest+=("$arg") ;;
     esac
   done

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -23,7 +23,7 @@ MARKETPLACE='TOMOSIA-VIETNAM/open-pr'
 usage() {
   cat <<'EOF'
 Usage: scripts/install-local.sh [--platform NAME] [--target DIR] [--copy]
-                                [--update | --uninstall [--all]]
+                                [--update [--ref NAME] | --uninstall [--all]]
 
   --platform NAME  repeatable, or comma-separated: --platform cursor,shared
                    all          every platform below, Claude Code included
@@ -39,7 +39,10 @@ Usage: scripts/install-local.sh [--platform NAME] [--target DIR] [--copy]
   --target DIR     install somewhere else; one platform at a time, wins over its path
   --copy           copy instead of linking (needed if your platform will not follow symlinks);
                    afterwards a `git pull` requires re-running this script
-  --update         git pull in this clone, then reinstall with the same options
+  --update         move this clone to the ref it follows, then reinstall with the same options.
+                   That ref is whatever the last --ref named, else the newest release
+  --ref NAME       with --update: move to this branch or tag and follow it. `--ref latest` returns
+                   to releases
   --uninstall      remove only what this script installed, then exit
   --all            with --uninstall: sweep every platform above
 
@@ -89,6 +92,7 @@ SWEEP=no
 TARGET=
 MODE=link
 ACTION=install
+REF=
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -99,6 +103,9 @@ while [ $# -gt 0 ]; do
     --uninstall) ACTION=uninstall; shift ;;
     --all) SWEEP=yes; shift ;;
     --update) ACTION=update; shift ;;
+    --ref) [ $# -ge 2 ] && [ -n "$2" ] || {
+             printf 'install-local.sh: --ref needs a branch or tag name, or `latest`\n' >&2; exit 2; }
+           REF="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) printf 'install-local.sh: unexpected argument %s\n' "$1" >&2; usage >&2; exit 2 ;;
   esac
@@ -107,6 +114,63 @@ done
 if [ "$SWEEP" = yes ]; then
   [ "$ACTION" = uninstall ] || { printf 'install-local.sh: --all only applies to --uninstall\n' >&2; exit 2; }
   [ -z "$TARGET" ] || { printf 'install-local.sh: --all and --target are mutually exclusive\n' >&2; exit 2; }
+fi
+if [ -n "$REF" ] && [ "$ACTION" != update ]; then
+  printf 'install-local.sh: --ref only applies to --update; a ref is checked out by install.sh --ref\n' >&2
+  exit 2
+fi
+
+# Before anything is asked about platforms: the update replaces this file and hands over to the new
+# copy, and a question answered here would be lost across that hand-over and asked again.
+if [ "$ACTION" = update ]; then
+  say 'updating %s\n' "$REPO"
+  # A ref this clone follows — named by install.sh --ref, or by --ref on an earlier update — is where
+  # it belongs. `latest` gives that up and asks for the release channel again, and a clone following
+  # nothing is already on it.
+  release=no
+  if [ "$REF" = latest ]; then
+    git -C "$REPO" config --unset open-pr.ref 2>/dev/null || true
+    REF=; release=yes
+  else
+    [ -n "$REF" ] || REF="$(git -C "$REPO" config --get open-pr.ref 2>/dev/null || true)"
+  fi
+  if [ -n "$REF" ]; then
+    up="$REF"
+    git -C "$REPO" fetch --quiet --depth 1 origin "$up" \
+      || { printf 'install-local.sh: origin has no ref named %s\n' "$up" >&2; exit 1; }
+    git -C "$REPO" checkout --quiet --detach FETCH_HEAD
+    git -C "$REPO" config open-pr.ref "$up"
+    say 'now at %s — following it, --ref latest returns to releases\n' "$up"
+  elif [ "$release" = no ] && git -C "$REPO" symbolic-ref -q HEAD >/dev/null; then
+    up="$(git -C "$REPO" rev-parse --abbrev-ref HEAD)"
+    git -C "$REPO" pull --ff-only
+  else
+    # Installed at a release tag, so the clone's fetch refspec is that one tag and `git pull` can
+    # only ever report itself up to date. Ask the remote which release is newest and move onto it.
+    up="$(git -C "$REPO" ls-remote --tags --refs origin 'v[0-9]*' 2>/dev/null \
+          | awk -F/ '{print $NF}' | sort -t. -k1.2,1n -k2,2n -k3,3n | tail -1)"
+    [ -n "$up" ] || up=HEAD
+    git -C "$REPO" fetch --quiet --depth 1 origin "$up" \
+      || { printf 'install-local.sh: could not fetch %s from origin\n' "$up" >&2; exit 1; }
+    git -C "$REPO" checkout --quiet --detach FETCH_HEAD
+    say 'now at %s\n' "$up"
+  fi
+  # The update just rewrote this file while bash is part way through reading it. Hand over to the
+  # new copy rather than run the rest of the old one from shifted byte offsets. The flags that got it
+  # here are spent: the move is done and the ref is recorded.
+  rest=()
+  drop_value=no
+  for arg in ${ORIG_ARGS+"${ORIG_ARGS[@]}"}; do
+    if [ "$drop_value" = yes ]; then drop_value=no; continue; fi
+    case "$arg" in
+      --update) ;;
+      --ref) drop_value=yes ;;
+      *) rest+=("$arg") ;;
+    esac
+  done
+  [ -x "$REPO/scripts/install-local.sh" ] || {
+    printf 'install-local.sh: %s has no installer — nothing was reinstalled\n' "$up" >&2; exit 1; }
+  exec "$REPO/scripts/install-local.sh" ${rest+"${rest[@]}"}
 fi
 
 # No platform given: ask, rather than guess on the user's behalf which agent they run. Piped into a
@@ -166,32 +230,6 @@ resolve_members() {
     exit 2
   fi
 }
-
-if [ "$ACTION" = update ]; then
-  say 'updating %s\n' "$REPO"
-  if git -C "$REPO" symbolic-ref -q HEAD >/dev/null; then
-    git -C "$REPO" pull --ff-only
-  else
-    # Installed at a release tag, so the clone's fetch refspec is that one tag and `git pull` can
-    # only ever report itself up to date. Ask the remote which release is newest and move onto it.
-    up="$(git -C "$REPO" ls-remote --tags --refs origin 'v[0-9]*' 2>/dev/null \
-          | awk -F/ '{print $NF}' | sort -t. -k1.2,1n -k2,2n -k3,3n | tail -1)"
-    [ -n "$up" ] || up=HEAD
-    git -C "$REPO" fetch --quiet --depth 1 origin "$up" \
-      || { printf 'install-local.sh: could not fetch %s from origin\n' "$up" >&2; exit 1; }
-    git -C "$REPO" checkout --quiet --detach FETCH_HEAD
-    say 'now at %s\n' "$up"
-  fi
-  # The update just rewrote this file while bash is part way through reading it. Hand over to the
-  # new copy rather than run the rest of the old one from shifted byte offsets.
-  rest=()
-  for arg in ${ORIG_ARGS+"${ORIG_ARGS[@]}"}; do
-    [ "$arg" = --update ] || rest+=("$arg")
-  done
-  [ -x "$REPO/scripts/install-local.sh" ] || {
-    printf 'install-local.sh: %s has no installer — nothing was reinstalled\n' "$up" >&2; exit 1; }
-  exec "$REPO/scripts/install-local.sh" ${rest+"${rest[@]}"}
-fi
 
 SKILLS=()
 for dir in "$REPO"/skills/open-pr-*; do

--- a/tests/test_prompt_graph.py
+++ b/tests/test_prompt_graph.py
@@ -1324,6 +1324,34 @@ def test_install_paths_have_one_owner():
     assert not missing, f"the ROOT fallback cannot find installs in: {missing}"
 
 
+def test_the_platform_question_is_asked_once_per_run():
+    """--update replaces install-local.sh and hands over to the new copy, and the answer to the
+    platform question does not survive that hand-over. Asked before the update, it is asked again
+    after — the same menu twice for one install. Two things keep it to one: the update runs before
+    anything is asked, and install.sh, which has already moved the clone itself, does not pass
+    --update down to a second mover."""
+    script = (REPO / "scripts" / "install-local.sh").read_text(encoding="utf-8")
+    update = script.index('if [ "$ACTION" = update ]')
+    ask = script.index("say 'Which platform?")
+    assert update < ask, "install-local.sh asks which platform before the update hands over"
+
+    bootstrap = (REPO / "install.sh").read_text(encoding="utf-8")
+    assert re.search(r"^\s*--update\) shift ;;", bootstrap, re.M), (
+        "install.sh forwards --update to install-local.sh, which then updates and re-execs a "
+        "second time")
+
+
+def test_an_install_off_the_release_channel_stays_there():
+    """--ref installs a branch so a big change can be tried before it merges. Both scripts then have
+    to read back what this clone follows, or the next update pulls the user onto a release and the
+    branch they were testing is gone without a word."""
+    for name in ("install.sh", "scripts/install-local.sh"):
+        script = (REPO / name).read_text(encoding="utf-8")
+        assert "config --get open-pr.ref" in script, f"{name} never reads back the ref it follows"
+        assert re.search(r"config open-pr\.ref", script), f"{name} never records the ref it follows"
+        assert "latest" in script, f"{name} offers no way back to the release channel"
+
+
 def test_local_installer_covers_every_shim():
     """It discovers skills by glob, but its closing message names them. A fifth command must
     show up there too, or users never learn it exists."""

--- a/tests/test_prompt_graph.py
+++ b/tests/test_prompt_graph.py
@@ -1349,7 +1349,8 @@ def test_an_install_off_the_release_channel_stays_there():
         script = (REPO / name).read_text(encoding="utf-8")
         assert "config --get open-pr.ref" in script, f"{name} never reads back the ref it follows"
         assert re.search(r"config open-pr\.ref", script), f"{name} never records the ref it follows"
-        assert "latest" in script, f"{name} offers no way back to the release channel"
+        assert "config --unset open-pr.ref" in script, (
+            f"{name} offers no way back to the release channel")
 
 
 def test_local_installer_covers_every_shim():


### PR DESCRIPTION
## Description

**`--update` asked which platform twice.** `install-local.sh` asked before its update block. The update then replaced the script on disk and `exec`'d the new copy, and the answer did not survive that hand-over — so the new copy asked again. `install.sh` compounded it: it had already moved the clone onto the wanted ref, then still forwarded `--update`, so the whole update ran a second time. Plain `install` never showed it because nothing re-execs on that path.

The update now runs before anything is asked, and `install.sh` keeps `--update` to itself.

**An install could not follow a branch.** The one-liner always took the newest release tag. `OPEN_PR_REF` could name a branch but was undocumented, and the next `--update` pulled the clone back onto a release tag without saying so — a big change on a branch could not be handed to anyone to try before it merged.

`--ref <branch-or-tag>` installs that ref and records it in the clone's own `git config` (`open-pr.ref`) — untracked, survives a checkout, read back by both scripts. Every later run fetches that ref again. `--ref latest` clears it and returns to the release channel. `--ref` also works on `install-local.sh --update`.

**`gemini-extension.json` declared `1.4.0` against release tag `v1.4.1`.** The one declared version had fallen behind, which `test_the_declared_version_keeps_up_with_the_release_tags` was already failing on before this branch. Bumped to `1.4.1`.

## Type of change

- [ ] 🔴 Breaking change (changes config/output behavior that repos using the plugin depend on)
- [x] ✨ New feature
- [x] 🐛 Bug fix
- [ ] 📝 Docs (README/CLAUDE.md, no runtime behavior change)
- [x] 🔧 Chore (refactor, tooling, no user-visible behavior change)

## How was this tested

Both scripts run against a throwaway bare origin (one release tag, one branch carrying a marker commit) with `HOME` and `OPEN_PR_HOME` pointed at temp directories, so nothing touched a real install. The no-terminal fallback and the platform menu are the same block, so counting the fallback line counts how many times that block was reached:

| run | block reached | follows | on the branch |
| --- | --- | --- | --- |
| install, default | 1 | — | no |
| `--update` | 1 | — | no |
| `--ref feat/big`, fresh clone and existing clone | 1 | `feat/big` | yes |
| `--update` after that (via `install.sh` and via `install-local.sh`) | 1 | `feat/big` | yes |
| `--update --ref latest` | 1 | — | no |
| `--ref=v0.0.1`, `OPEN_PR_REF=main`, `--copy`, `--platform` | 1 | as named | — |
| `--uninstall` | — | — | clone and every link gone |

`--ref` with no value, `--ref` without `--update`, and a ref that does not exist all exit non-zero with a named reason.

Two tests lock the invariants and both fail on the previous scripts (`assert 7389 < 5533`; `'config --get open-pr.ref' not in ...`):
- `test_the_platform_question_is_asked_once_per_run`
- `test_an_install_off_the_release_channel_stays_there`

`scripts/check.sh main`: 80 passed, duplication scan clean, context cost `+0.0%` on all 16 scenarios (nothing under `src/`).

## Checklist

- [x] `scripts/check.sh <base-ref>` passes — suite, duplication scan, context cost
- [x] Context cost: cheaper → lower ceilings; costlier for a correct fix → PR says which
  scenario, by how much, and why. Never strip behaviour for budget
- [x] `tests/token-history.json` and `token-history.svg` untouched
- [x] Behavior/architecture change → updated `CLAUDE.md` accordingly — no change needed; `CLAUDE.md` names `install.sh` and `scripts/install-local.sh` by role, not by flag
- [x] Anything a user sees → `docs/install.md` and each `docs/<lang>/install.md` carry the new `Install a branch` section. The READMEs state the install one-liner only and name no flag, so none was added there
- [x] Added a config field → none
- [x] Changed the config shape an EXISTING repo already has → none
- [x] No new `allowed-tools` grant
