### PR TITLE
fix(ci): run the checks without any external action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
 
+# No `uses:` in this workflow. The org allows Actions only from repositories it owns, so
+# actions/checkout and actions/setup-python failed the whole run at startup and not one
+# check ever executed. A local composite action cannot stand in for the checkout either:
+# `uses: ./...` needs the repository on disk before it can resolve.
+
 on:
   pull_request:
   push:
@@ -13,20 +18,31 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0   # token_report needs the base branch to diff against
+      # Full history and every tag: token_report diffs against the base branch, and the
+      # declared-version test reads the release tags. The repository is public, so this
+      # needs no token — GITHUB_REF is refs/pull/<n>/merge on a pull request and
+      # refs/heads/main on a push, and both are fetchable anonymously.
+      - name: Check out the ref under test
+        run: |
+          set -euo pipefail
+          git init -q .
+          git remote add origin "https://github.com/$GITHUB_REPOSITORY"
+          git fetch -q --tags origin \
+            "+refs/heads/*:refs/remotes/origin/*" "+$GITHUB_REF:refs/ci/head"
+          git checkout -q --detach refs/ci/head
 
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: '3.12'
-          cache: pip
-          # The only dependency file in the repo is requirements-dev.txt; the cache
-          # default globs requirements.txt/pyproject.toml and errors out when neither
-          # exists, which failed the job before a single check had run.
-          cache-dependency-path: requirements-dev.txt
-
-      - run: pip install -r requirements-dev.txt
+      # setup-python is an action, so the interpreter is whatever the runner image ships.
+      # The version is asserted rather than assumed: an image bump that moves the minor
+      # version fails here instead of somewhere downstream. The dependencies go in a venv
+      # because the image's python is externally managed and rejects a plain pip install;
+      # GITHUB_PATH puts that venv first for every step after this one.
+      - name: Python and the dev dependencies
+        run: |
+          set -euo pipefail
+          python3 -c 'import sys; assert sys.version_info[:2] == (3, 12), sys.version'
+          python3 -m venv "$RUNNER_TEMP/venv"
+          "$RUNNER_TEMP/venv/bin/python" -m pip install --quiet -r requirements-dev.txt
+          echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
 
       - name: Prompt-graph invariants
         run: python3 -m pytest tests/ -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ scripts/          check.sh · token_report.py · dup_scan.py · vendor_lint.py �
 tests/            test_prompt_graph.py · budgets.json · duplication_allowlist.json
 e2e/              real-run fixture; never in CI
 .claude/skills/   dev skills (`e2e-loop`)
-.github/workflows ci.yml + hol-plugin-scanner.yml on PRs (both blocked at startup)
+.github/workflows ci.yml on PRs · hol-plugin-scanner.yml read by the listing gate, never runs
 backlogs/         historical, not ops
 ```
 
@@ -86,8 +86,11 @@ Cheaper → lower affected ceilings (by hand by the measured delta if you had ti
 
 Numbers move the wrong way: suspect the measurement first (missing path in base, a `cp`'d seed counted as a load). Fix the model, then judge the content.
 
-The org restricts Actions to repositories it owns, so every workflow here fails at startup —
-`actions/checkout` included, whatever the ref. Checks run locally; `scripts/install_hooks.sh`
-wires them to pre-push. The workflows are still kept correct and their `uses:` SHA-pinned:
-`hol-plugin-scanner.yml` exists because the awesome-ai-plugins listing gate reads the file,
-and the scanner scores an unpinned `uses:` as an operational-security finding.
+The org allows Actions only from repositories it owns — `actions/checkout` included, whatever
+the ref — and a `uses:` naming any other owner fails the whole workflow at startup, before a
+step runs. So `ci.yml` carries no `uses:` at all: it fetches the ref with `git` and uses the
+runner image's own python. Add no action to it. `hol-plugin-scanner.yml` is the exception and
+stays broken on purpose: the awesome-ai-plugins listing gate reads that file for the vendor
+`uses:` and never looks at the run, and the catalog scans this repository from its own runner.
+Keep every `uses:` there SHA-pinned — the scanner scores an unpinned one as a finding.
+`scripts/install_hooks.sh` wires the same checks to pre-push.


### PR DESCRIPTION
Every run of the CI workflow has failed at startup, so no check has ever executed in this repository. The org allows Actions only from repositories it owns, and `actions/checkout` is not one of them — the ref makes no difference, tag or SHA:

```
The actions actions/checkout@v4 and actions/setup-python@v5 are not allowed in
TOMOSIA-VIETNAM/open-pr because all actions must be from a repository owned by TOMOSIA-VIETNAM.
```

A local composite action is no way round it either: `uses: ./...` needs the repository on disk before it resolves, which is the step being replaced.

So `ci.yml` has no `uses:` left. The checks themselves are untouched — same pytest, dup_scan, vendor_lint, token_report, in the same order.

- **Checkout** is `git init` + `git fetch` + `git checkout`, full history and every tag, because token_report diffs against the base branch and the declared-version test reads the release tags. The repository is public, so the fetch needs no token; `GITHUB_REF` is the merge ref on a pull request and the branch on a push, and both are fetchable anonymously.
- **Python** is the runner image's own. The version is asserted rather than assumed, so an image bump that moves the minor version fails at that step instead of somewhere downstream. Dependencies go in a venv because the image's python is externally managed and refuses a plain pip install; `GITHUB_PATH` puts that venv first for the steps after it.
- **pip caching** goes with setup-python, and the `cache-dependency-path` added for it goes too rather than staying as config nothing reads.

`hol-plugin-scanner.yml` is left alone and still fails at startup on purpose. The awesome-ai-plugins listing gate reads that file for the vendor `uses:` and never looks at the run, and the catalog scans this repository from its own runner.

Worth stating plainly: this is not a security improvement. A `run:` step that curls a .deb and installs from PyPI carries the same supply-chain exposure as before — it simply is not what the Actions policy covers. If the intent is to keep third-party code off the runner, the answer is an org allowlist for `actions/*`, not this.

**Verified locally**, since no CI run exists to prove it:

```
check.sh        80 passed · no duplication · clean on 3 vendor(s)
scanner         critical:0  high:0  Final Score: 85
listing gate    GATE PASSES: True
```

The git sequence was run for real against this repository with no credentials: it fetched a pull ref, every branch, all 14 tags, and produced a correct working tree with `origin/main` present for `token_report --base`.

Three things only the first real run can settle: that `python3` on `ubuntu-latest` is 3.12 (asserted, so it fails loudly), that `$GITHUB_REF` resolves on a `pull_request` event (only `refs/pull/<n>/head` was testable locally, as the other PRs are merged), and that the venv install clears PEP 668.