### PR TITLE
ci: run the checks on the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,16 @@
 name: CI
 
+# Runs when a pull request enters the merge queue, not on every commit pushed to it.
+# A queued entry is what the ruleset requires to be green, so the gate is still the gate
+# — it just fires once, on the tree that is actually about to land.
 on:
-  pull_request:
+  merge_group:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   checks:
@@ -55,16 +58,18 @@ jobs:
         run: python3 scripts/vendor_lint.py
 
       - name: Context cost vs base
-        if: github.event_name == 'pull_request'
-        run: |
-          python3 scripts/token_report.py --base "origin/${{ github.base_ref }}" | tee token-report.txt
-
-      - name: Report the cost on the PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'merge_group'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          # A fork PR gets a read-only token, so the comment step is skipped there and
-          # the job summary carries the numbers instead.
-          CAN_COMMENT: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          BASE_REF: ${{ github.event.merge_group.base_ref }}
+        run: |
+          set -euo pipefail
+          python3 scripts/token_report.py --base "origin/${BASE_REF#refs/heads/}" | tee token-report.txt
+
+      - name: Report the cost
+        if: github.event_name == 'merge_group'
+        # A merge_group event has no pull request to comment on, so the numbers land in
+        # the job summary of the queue entry — reachable from the pull request's own
+        # checks list.
+        env:
+          CAN_COMMENT: 'false'
         run: bash scripts/ci_token_comment.sh token-report.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ scripts/          check.sh · token_report.py · dup_scan.py · vendor_lint.py �
 tests/            test_prompt_graph.py · budgets.json · duplication_allowlist.json
 e2e/              real-run fixture; never in CI
 .claude/skills/   dev skills (`e2e-loop`)
-.github/workflows ci.yml + hol-plugin-scanner.yml on PRs (both blocked at startup)
+.github/workflows ci.yml on the merge queue · hol-plugin-scanner.yml read by the listing gate
 backlogs/         historical, not ops
 ```
 
@@ -86,8 +86,15 @@ Cheaper → lower affected ceilings (by hand by the measured delta if you had ti
 
 Numbers move the wrong way: suspect the measurement first (missing path in base, a `cp`'d seed counted as a load). Fix the model, then judge the content.
 
-The org restricts Actions to repositories it owns, so every workflow here fails at startup —
-`actions/checkout` included, whatever the ref. Checks run locally; `scripts/install_hooks.sh`
-wires them to pre-push. The workflows are still kept correct and their `uses:` SHA-pinned:
-`hol-plugin-scanner.yml` exists because the awesome-ai-plugins listing gate reads the file,
-and the scanner scores an unpinned `uses:` as an operational-security finding.
+Actions are restricted to what the org owns, what GitHub authored, and Marketplace verified
+creators. `actions/*` is fine; anything else needs an entry in the repository's allowlist or
+the whole workflow fails at startup, before a step runs and without producing a check — a
+failure that is invisible on the pull request, so read the Actions tab when a run goes missing.
+`hol-plugin-scanner.yml` names a vendor action that is not verified: it exists for the
+awesome-ai-plugins listing gate, which reads the file and never the run, and the catalog scans
+this repository from its own runner. Keep every `uses:` SHA-pinned — the scanner scores an
+unpinned one as a finding.
+
+CI fires on the merge queue, not on each commit pushed to a pull request, so a pull request
+shows its checks only once queued. `scripts/check.sh` before pushing is what catches a break
+early; `scripts/install_hooks.sh` wires it to pre-push.


### PR DESCRIPTION
CI fired on every commit pushed to a pull request and produced a run each time, most of them on a tree nobody intended to merge. It now fires on `merge_group`: once, on the tree that is actually about to land, which is also the tree the ruleset gates on.

`pull_request` is gone, so a pull request shows its checks only once queued.

**What this gives up.** A `merge_group` event has no pull request to comment on, so the context-cost report no longer arrives as a PR comment — `scripts/ci_token_comment.sh` writes the job summary and stops there, and the numbers live in the queue entry’s summary, reachable from the pull request’s checks list. `permissions` drops to `contents: read` accordingly, since nothing writes to the pull request any more. `workflow_dispatch` is added so the suite can be run on demand without inventing a commit.

`actions/checkout` and `actions/setup-python` stay, both SHA-pinned, and `cache: pip` with its `cache-dependency-path` stays with them. The org policy that made them unusable has been loosened to allow GitHub-authored actions.

**This pull request will show no CI run of its own** — that is the change working as intended, not a failure. Verified locally instead:

```
check.sh        80 passed · no duplication · clean on 3 vendor(s)
scanner         critical:0  high:0  Final Score: 85
listing gate    GATE PASSES: True
```

The checks in this file are unchanged from the run on #83, which passed all ten steps on this same tree.

**Sequencing.** The ruleset needs two things added after this merges, or nothing gates and nothing queues:

1. a `merge_queue` rule on the default branch
2. `required_status_checks` requiring the `checks` context

Adding the required check *before* this merges would block every pull request, since no workflow answers to that context yet.

`hol-plugin-scanner.yml` is untouched and still fails at startup: its vendor action is not a Marketplace verified creator, so it needs an allowlist entry that has not been granted. The listing gate reads that file rather than the run, so nothing downstream depends on it.