### PR TITLE
docs: state how to run the CI suite on demand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Run until green. The suite proves the graph still holds — not that a rule you 
 | harder dup hunt | `dup_scan.py --window 10 --all --min-waste 20` |
 | vendor flags offline | `vendor_lint.py` |
 | vendor commands live | `vendor_lint.py --pr <n>` |
+| the CI suite on a branch, without a queue entry | `gh workflow run ci.yml --ref <branch>` |
 
 Cheaper → lower affected ceilings (by hand by the measured delta if you had tightened them; otherwise `--update-budgets` is fine). Costlier because the fix is correct → say which scenario / by how much / why on the PR. Never strip behaviour for budget.
 


### PR DESCRIPTION
CI answers to the merge queue now, so a branch gets no run of its own. `ci.yml` carries `workflow_dispatch` for exactly that case, but nothing said so — the table of what to run listed only the local scripts.

This also serves as the first entry through the merge queue, which is the one path the previous pull request could not exercise: `github.event.merge_group.base_ref` and the `checks` context reaching the ruleset are both unproven until an entry is actually queued.