### PR TITLE
fix(ci): put the checks back on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,24 @@
 name: CI
 
-# Runs when a pull request enters the merge queue, not on every commit pushed to it.
-# A queued entry is what the ruleset requires to be green, so the gate is still the gate
-# — it just fires once, on the tree that is actually about to land.
+# A merge queue cannot replace this. GitHub only makes the queue wait on checks the
+# ruleset marks required, and it refuses to queue a pull request whose required checks
+# have not already passed on the pull request itself — so a required check has to run
+# here, on pull_request, or it never runs at all.
 on:
-  merge_group:
+  pull_request:
   push:
     branches: [main]
   workflow_dispatch:
 
+# Three commits pushed in a row spend one run, on the last of them. Runs on main are
+# never cancelled: each one records a distinct commit that landed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   checks:
@@ -58,18 +66,16 @@ jobs:
         run: python3 scripts/vendor_lint.py
 
       - name: Context cost vs base
-        if: github.event_name == 'merge_group'
-        env:
-          BASE_REF: ${{ github.event.merge_group.base_ref }}
+        if: github.event_name == 'pull_request'
         run: |
-          set -euo pipefail
-          python3 scripts/token_report.py --base "origin/${BASE_REF#refs/heads/}" | tee token-report.txt
+          python3 scripts/token_report.py --base "origin/${{ github.base_ref }}" | tee token-report.txt
 
-      - name: Report the cost
-        if: github.event_name == 'merge_group'
-        # A merge_group event has no pull request to comment on, so the numbers land in
-        # the job summary of the queue entry — reachable from the pull request's own
-        # checks list.
+      - name: Report the cost on the PR
+        if: github.event_name == 'pull_request'
         env:
-          CAN_COMMENT: 'false'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # A fork PR gets a read-only token, so the comment step is skipped there and
+          # the job summary carries the numbers instead.
+          CAN_COMMENT: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: bash scripts/ci_token_comment.sh token-report.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ scripts/          check.sh · token_report.py · dup_scan.py · vendor_lint.py �
 tests/            test_prompt_graph.py · budgets.json · duplication_allowlist.json
 e2e/              real-run fixture; never in CI
 .claude/skills/   dev skills (`e2e-loop`)
-.github/workflows ci.yml on the merge queue · hol-plugin-scanner.yml read by the listing gate
+.github/workflows ci.yml on PRs and main · hol-plugin-scanner.yml read by the listing gate
 backlogs/         historical, not ops
 ```
 
@@ -81,7 +81,7 @@ Run until green. The suite proves the graph still holds — not that a rule you 
 | harder dup hunt | `dup_scan.py --window 10 --all --min-waste 20` |
 | vendor flags offline | `vendor_lint.py` |
 | vendor commands live | `vendor_lint.py --pr <n>` |
-| the CI suite on a branch, without a queue entry | `gh workflow run ci.yml --ref <branch>` |
+| the CI suite on a branch with no open PR | `gh workflow run ci.yml --ref <branch>` |
 
 Cheaper → lower affected ceilings (by hand by the measured delta if you had tightened them; otherwise `--update-budgets` is fine). Costlier because the fix is correct → say which scenario / by how much / why on the PR. Never strip behaviour for budget.
 
@@ -96,6 +96,9 @@ awesome-ai-plugins listing gate, which reads the file and never the run, and the
 this repository from its own runner. Keep every `uses:` SHA-pinned — the scanner scores an
 unpinned one as a finding.
 
-CI fires on the merge queue, not on each commit pushed to a pull request, so a pull request
-shows its checks only once queued. `scripts/check.sh` before pushing is what catches a break
-early; `scripts/install_hooks.sh` wires it to pre-push.
+CI runs on every pull request, and a new push cancels the run still going for that same pull
+request. A merge queue cannot take its place: GitHub makes the queue wait only on checks the
+ruleset marks required, and refuses to queue a pull request whose required checks have not
+already passed on the pull request — so the check runs on `pull_request` or nowhere. Running
+`scripts/check.sh` before pushing is still what catches a break early; `scripts/install_hooks.sh`
+wires it to pre-push.


### PR DESCRIPTION
Moving CI to `merge_group` left pull requests with no checks at all, and the queue merged one without running anything. Two facts, found by testing rather than reading:

- GitHub makes the merge queue wait only on checks the ruleset marks **required**. With no required check, the queue merged an entry immediately — zero `merge_group` runs.
- With a required check, `enqueuePullRequest` refuses the pull request outright: `Pull request Required status check "checks" is expected.` The check has to have passed **on the pull request** before it can be queued.

Together: the check runs on `pull_request`, or it never runs. A queue can only re-verify what already passed; it cannot be the only place a check runs. The merge-queue rule has been removed from the ruleset, which is back to the four rules it had before.

The waste that motivated the move is handled where it belongs:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Three commits pushed in a row spend one run instead of three. Runs on `main` are never cancelled — each records a commit that landed. `workflow_dispatch` stays, for a branch with no open pull request.

The context-cost comment and the `pull-requests: write` it needs come back with the trigger.

**Verified locally**:

```
check.sh        80 passed · no duplication · clean on 3 vendor(s)
scanner         high:0  Final Score: 85
listing gate    True
```

This pull request produces its own CI run — the merge ref carries the restored trigger — so it proves the fix rather than asserting it.

`hol-plugin-scanner.yml` is untouched. It fails at startup because its vendor action is not a Marketplace verified creator and is not on the repository allowlist, and that is fine: the awesome-ai-plugins gate reads the file for the `uses:` and the trigger, never the run, and the catalog scores this repository from its own runner. Nothing downstream needs it to execute.