### PR TITLE
feat(commands): allow model-invocation of open-pr commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Vendors: GitHub, GitLab, Bitbucket.
 ## Layout
 
 ```
-src/commands/     entry points; only these have frontmatter; each `disable-model-invocation: true`
+src/commands/     entry points; only these have frontmatter
 src/core/         shared procedure
 src/setup/        bootstrap, doctor, template, lesson
 src/cases/        gated branches — Read only when the condition matches

--- a/src/commands/clean.md
+++ b/src/commands/clean.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[repo name...]"
 description: Remove the git worktrees review checked PR code out into. Each one is a full checkout on disk; nothing else is touched.
-disable-model-invocation: true
 ---
 
 > **CRITICAL:** `Read` `"${CLAUDE_PLUGIN_ROOT}"/core/guardrails.md` FIRST — shared rules, not repeated

--- a/src/commands/feedback.md
+++ b/src/commands/feedback.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[what should be better]"
 description: Report a problem with the open-pr plugin itself, or ask for a change, on its public issue tracker. Reads no PR; writes nothing in your repo.
-disable-model-invocation: true
 ---
 
 > **CRITICAL:** `Read` `"${CLAUDE_PLUGIN_ROOT}"/core/guardrails.md` FIRST — shared rules, not repeated

--- a/src/commands/fix.md
+++ b/src/commands/fix.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[PR URL] [content]"
 description: Act on the findings a review left on a PR — takes or declines each by severity, edits code at pwd to match the project, 1 commit, replies once pushed.
-disable-model-invocation: true
 ---
 
 > **CRITICAL:** `Read` `"${CLAUDE_PLUGIN_ROOT}"/core/guardrails.md` FIRST — shared rules, not repeated

--- a/src/commands/review.md
+++ b/src/commands/review.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "<PR URL> [other PR URL...] [content]"
 description: Review PRs against the conventions learned from each repo — 1 post per PR, findings tagged by severity, code left untouched.
-disable-model-invocation: true
 ---
 
 > **CRITICAL:** `Read` `"${CLAUDE_PLUGIN_ROOT}"/core/guardrails.md` FIRST — shared rules, not repeated

--- a/src/commands/upgrade.md
+++ b/src/commands/upgrade.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[repo name...]"
 description: Bring every per-repo config found below pwd up to the schema this build expects. Takes no PR.
-disable-model-invocation: true
 ---
 
 > **CRITICAL:** `Read` `"${CLAUDE_PLUGIN_ROOT}"/core/guardrails.md` FIRST — shared rules, not repeated

--- a/tests/test_prompt_graph.py
+++ b/tests/test_prompt_graph.py
@@ -606,19 +606,6 @@ def test_frontmatter_only_in_commands():
         assert has == rel(p).startswith("commands/"), f"{rel(p)}: frontmatter={has}"
 
 
-def test_commands_are_never_model_invoked():
-    """These commands post a review, commit and push, delete worktrees, or open a public
-    issue. `disable-model-invocation: true` keeps the harness from firing one on its own
-    reading of the chat, leaving `/open-pr:<cmd>` the only way in on Claude Code, and keeps each
-    description out of every unrelated session's always-loaded context.
-    """
-    for p in md_files():
-        if not rel(p).startswith("commands/"):
-            continue
-        assert re.search(r"^disable-model-invocation: true$", text(p), re.M), \
-            f"{rel(p)}: missing disable-model-invocation"
-
-
 def test_every_file_is_reachable_from_a_command():
     """A file nothing leads to still ships to every user and still rots."""
     graph, files = {}, {rel(p) for p in md_files()}


### PR DESCRIPTION
## Summary
- Removes `disable-model-invocation: true` from the 5 command frontmatters (`review`, `fix`, `clean`, `feedback`, `upgrade`) so Claude Code can auto-invoke them from conversation, not only via explicit `/open-pr:<cmd>`.
- Drops `test_commands_are_never_model_invoked`, which asserted the old guard, and the stale doc line in `CLAUDE.md`.

## Note
These commands have real side effects (post a review, commit+push, delete worktrees, open a public issue). The removed guard existed specifically to keep the harness from firing one on its own reading of chat. Confirmed with the requester before applying.

## Test plan
- [x] `scripts/check.sh origin/main` — 79 tests pass, no duplication findings, token deltas only from the removed frontmatter line