### PR TITLE
chore(chart): context cost at v1.4.2

### DIFF
--- a/tests/token-history.json
+++ b/tests/token-history.json
@@ -103,6 +103,15 @@
       "upgrade": 2209,
       "clean": 1295,
       "feedback": 2133
+    },
+    {
+      "tag": "v1.4.2",
+      "date": "2026-08-27",
+      "review": 11992,
+      "fix": 9393,
+      "upgrade": 2202,
+      "clean": 1288,
+      "feedback": 2126
     }
   ]
 }

--- a/token-history.svg
+++ b/token-history.svg
@@ -20,75 +20,81 @@
 <line x1="62" y1="55.0" x2="702" y2="55.0" stroke="#8b949e" stroke-opacity="0.25"/>
 <text x="54" y="58.5" text-anchor="end" font-size="10" fill="#8b949e">18k</text>
 <text x="78.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.1.0</text>
-<text x="128.7" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.0</text>
-<text x="179.3" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.1</text>
-<text x="230.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.3.0</text>
-<text x="280.7" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.0.0</text>
-<text x="331.3" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.0</text>
-<text x="382.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.1</text>
-<text x="432.7" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.2</text>
-<text x="483.3" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.0</text>
-<text x="534.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.1</text>
-<text x="584.7" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.3.0</text>
-<text x="635.3" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.0</text>
-<text x="686.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.1</text>
-<polyline points="78.0,130.9 128.7,79.8 179.3,85.3 230.0,70.0 280.7,125.5 331.3,125.2 382.0,125.4 432.7,125.3 483.3,125.3 534.0,123.6 584.7,117.0 635.3,119.9 686.0,113.7" fill="none" stroke="#2f81f7" stroke-width="2" stroke-linejoin="round"/>
+<text x="124.8" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.0</text>
+<text x="171.5" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.1</text>
+<text x="218.3" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.3.0</text>
+<text x="265.1" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.0.0</text>
+<text x="311.8" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.0</text>
+<text x="358.6" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.1</text>
+<text x="405.4" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.2</text>
+<text x="452.2" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.0</text>
+<text x="498.9" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.1</text>
+<text x="545.7" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.3.0</text>
+<text x="592.5" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.0</text>
+<text x="639.2" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.1</text>
+<text x="686.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.2</text>
+<polyline points="78.0,130.9 124.8,79.8 171.5,85.3 218.3,70.0 265.1,125.5 311.8,125.2 358.6,125.4 405.4,125.3 452.2,125.3 498.9,123.6 545.7,117.0 592.5,119.9 639.2,113.7 686.0,113.7" fill="none" stroke="#2f81f7" stroke-width="2" stroke-linejoin="round"/>
 <circle cx="78.0" cy="130.9" r="3" fill="#2f81f7"/>
-<circle cx="128.7" cy="79.8" r="3" fill="#2f81f7"/>
-<circle cx="179.3" cy="85.3" r="3" fill="#2f81f7"/>
-<circle cx="230.0" cy="70.0" r="3" fill="#2f81f7"/>
-<circle cx="280.7" cy="125.5" r="3" fill="#2f81f7"/>
-<circle cx="331.3" cy="125.2" r="3" fill="#2f81f7"/>
-<circle cx="382.0" cy="125.4" r="3" fill="#2f81f7"/>
-<circle cx="432.7" cy="125.3" r="3" fill="#2f81f7"/>
-<circle cx="483.3" cy="125.3" r="3" fill="#2f81f7"/>
-<circle cx="534.0" cy="123.6" r="3" fill="#2f81f7"/>
-<circle cx="584.7" cy="117.0" r="3" fill="#2f81f7"/>
-<circle cx="635.3" cy="119.9" r="3" fill="#2f81f7"/>
+<circle cx="124.8" cy="79.8" r="3" fill="#2f81f7"/>
+<circle cx="171.5" cy="85.3" r="3" fill="#2f81f7"/>
+<circle cx="218.3" cy="70.0" r="3" fill="#2f81f7"/>
+<circle cx="265.1" cy="125.5" r="3" fill="#2f81f7"/>
+<circle cx="311.8" cy="125.2" r="3" fill="#2f81f7"/>
+<circle cx="358.6" cy="125.4" r="3" fill="#2f81f7"/>
+<circle cx="405.4" cy="125.3" r="3" fill="#2f81f7"/>
+<circle cx="452.2" cy="125.3" r="3" fill="#2f81f7"/>
+<circle cx="498.9" cy="123.6" r="3" fill="#2f81f7"/>
+<circle cx="545.7" cy="117.0" r="3" fill="#2f81f7"/>
+<circle cx="592.5" cy="119.9" r="3" fill="#2f81f7"/>
+<circle cx="639.2" cy="113.7" r="3" fill="#2f81f7"/>
 <circle cx="686.0" cy="113.7" r="3" fill="#2f81f7"/>
-<polyline points="230.0,101.6 280.7,147.1 331.3,147.1 382.0,145.7 432.7,145.7 483.3,145.7 534.0,144.0 584.7,137.3 635.3,139.1 686.0,139.1" fill="none" stroke="#e3742f" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="230.0" cy="101.6" r="3" fill="#e3742f"/>
-<circle cx="280.7" cy="147.1" r="3" fill="#e3742f"/>
-<circle cx="331.3" cy="147.1" r="3" fill="#e3742f"/>
-<circle cx="382.0" cy="145.7" r="3" fill="#e3742f"/>
-<circle cx="432.7" cy="145.7" r="3" fill="#e3742f"/>
-<circle cx="483.3" cy="145.7" r="3" fill="#e3742f"/>
-<circle cx="534.0" cy="144.0" r="3" fill="#e3742f"/>
-<circle cx="584.7" cy="137.3" r="3" fill="#e3742f"/>
-<circle cx="635.3" cy="139.1" r="3" fill="#e3742f"/>
-<circle cx="686.0" cy="139.1" r="3" fill="#e3742f"/>
-<polyline points="280.7,210.5 331.3,210.5 382.0,210.5 432.7,210.5 483.3,210.5 534.0,209.4 584.7,209.4 635.3,209.4 686.0,209.4" fill="none" stroke="#a371f7" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="280.7" cy="210.5" r="3" fill="#a371f7"/>
-<circle cx="331.3" cy="210.5" r="3" fill="#a371f7"/>
-<circle cx="382.0" cy="210.5" r="3" fill="#a371f7"/>
-<circle cx="432.7" cy="210.5" r="3" fill="#a371f7"/>
-<circle cx="483.3" cy="210.5" r="3" fill="#a371f7"/>
-<circle cx="534.0" cy="209.4" r="3" fill="#a371f7"/>
-<circle cx="584.7" cy="209.4" r="3" fill="#a371f7"/>
-<circle cx="635.3" cy="209.4" r="3" fill="#a371f7"/>
-<circle cx="686.0" cy="209.4" r="3" fill="#a371f7"/>
-<polyline points="331.3,219.6 382.0,219.5 432.7,219.5 483.3,219.5 534.0,218.3 584.7,218.3 635.3,218.3 686.0,218.3" fill="none" stroke="#3fb950" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="331.3" cy="219.6" r="3" fill="#3fb950"/>
-<circle cx="382.0" cy="219.5" r="3" fill="#3fb950"/>
-<circle cx="432.7" cy="219.5" r="3" fill="#3fb950"/>
-<circle cx="483.3" cy="219.5" r="3" fill="#3fb950"/>
-<circle cx="534.0" cy="218.3" r="3" fill="#3fb950"/>
-<circle cx="584.7" cy="218.3" r="3" fill="#3fb950"/>
-<circle cx="635.3" cy="218.3" r="3" fill="#3fb950"/>
-<circle cx="686.0" cy="218.3" r="3" fill="#3fb950"/>
-<polyline points="584.7,210.7 635.3,210.7 686.0,210.1" fill="none" stroke="#db61a2" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="584.7" cy="210.7" r="3" fill="#db61a2"/>
-<circle cx="635.3" cy="210.7" r="3" fill="#db61a2"/>
-<circle cx="686.0" cy="210.1" r="3" fill="#db61a2"/>
+<polyline points="218.3,101.6 265.1,147.1 311.8,147.1 358.6,145.7 405.4,145.7 452.2,145.7 498.9,144.0 545.7,137.3 592.5,139.1 639.2,139.1 686.0,139.2" fill="none" stroke="#e3742f" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="218.3" cy="101.6" r="3" fill="#e3742f"/>
+<circle cx="265.1" cy="147.1" r="3" fill="#e3742f"/>
+<circle cx="311.8" cy="147.1" r="3" fill="#e3742f"/>
+<circle cx="358.6" cy="145.7" r="3" fill="#e3742f"/>
+<circle cx="405.4" cy="145.7" r="3" fill="#e3742f"/>
+<circle cx="452.2" cy="145.7" r="3" fill="#e3742f"/>
+<circle cx="498.9" cy="144.0" r="3" fill="#e3742f"/>
+<circle cx="545.7" cy="137.3" r="3" fill="#e3742f"/>
+<circle cx="592.5" cy="139.1" r="3" fill="#e3742f"/>
+<circle cx="639.2" cy="139.1" r="3" fill="#e3742f"/>
+<circle cx="686.0" cy="139.2" r="3" fill="#e3742f"/>
+<polyline points="265.1,210.5 311.8,210.5 358.6,210.5 405.4,210.5 452.2,210.5 498.9,209.4 545.7,209.4 592.5,209.4 639.2,209.4 686.0,209.5" fill="none" stroke="#a371f7" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="265.1" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="311.8" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="358.6" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="405.4" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="452.2" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="498.9" cy="209.4" r="3" fill="#a371f7"/>
+<circle cx="545.7" cy="209.4" r="3" fill="#a371f7"/>
+<circle cx="592.5" cy="209.4" r="3" fill="#a371f7"/>
+<circle cx="639.2" cy="209.4" r="3" fill="#a371f7"/>
+<circle cx="686.0" cy="209.5" r="3" fill="#a371f7"/>
+<polyline points="311.8,219.6 358.6,219.5 405.4,219.5 452.2,219.5 498.9,218.3 545.7,218.3 592.5,218.3 639.2,218.3 686.0,218.4" fill="none" stroke="#3fb950" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="311.8" cy="219.6" r="3" fill="#3fb950"/>
+<circle cx="358.6" cy="219.5" r="3" fill="#3fb950"/>
+<circle cx="405.4" cy="219.5" r="3" fill="#3fb950"/>
+<circle cx="452.2" cy="219.5" r="3" fill="#3fb950"/>
+<circle cx="498.9" cy="218.3" r="3" fill="#3fb950"/>
+<circle cx="545.7" cy="218.3" r="3" fill="#3fb950"/>
+<circle cx="592.5" cy="218.3" r="3" fill="#3fb950"/>
+<circle cx="639.2" cy="218.3" r="3" fill="#3fb950"/>
+<circle cx="686.0" cy="218.4" r="3" fill="#3fb950"/>
+<polyline points="545.7,210.7 592.5,210.7 639.2,210.1 686.0,210.2" fill="none" stroke="#db61a2" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="545.7" cy="210.7" r="3" fill="#db61a2"/>
+<circle cx="592.5" cy="210.7" r="3" fill="#db61a2"/>
+<circle cx="639.2" cy="210.1" r="3" fill="#db61a2"/>
+<circle cx="686.0" cy="210.2" r="3" fill="#db61a2"/>
 <circle cx="66" cy="18" r="3.5" fill="#2f81f7"/>
-<text x="75" y="21.5" font-size="11" fill="#8b949e">/open-pr:review 11,999</text>
+<text x="75" y="21.5" font-size="11" fill="#8b949e">/open-pr:review 11,992</text>
 <circle cx="246.0" cy="18" r="3.5" fill="#e3742f"/>
-<text x="255.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:fix 9,400</text>
+<text x="255.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:fix 9,393</text>
 <circle cx="398.0" cy="18" r="3.5" fill="#a371f7"/>
-<text x="407.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:upgrade 2,209</text>
+<text x="407.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:upgrade 2,202</text>
 <circle cx="66" cy="35" r="3.5" fill="#3fb950"/>
-<text x="75" y="38.5" font-size="11" fill="#8b949e">/open-pr:clean 1,295</text>
+<text x="75" y="38.5" font-size="11" fill="#8b949e">/open-pr:clean 1,288</text>
 <circle cx="232.0" cy="35" r="3.5" fill="#db61a2"/>
-<text x="241.0" y="38.5" font-size="11" fill="#8b949e">/open-pr:feedback 2,133</text>
+<text x="241.0" y="38.5" font-size="11" fill="#8b949e">/open-pr:feedback 2,126</text>
 <text x="62" y="269" font-size="9" fill="#8b949e" fill-opacity="0.85">mean per group · cl100k_base proxy · each point frozen at its release · tests/token-history.json</text>
 </svg>


### PR DESCRIPTION
One point per release tag on the context-cost chart, measured at v1.4.2 by `scripts/token_chart.py --add`. The SVG is redrawn from those numbers, never hand-edited — the suite redraws it and compares.