### PR TITLE
feat(review): check a cross-file assumption before concluding on it

### DIFF
--- a/.claude/commands/release-now.md
+++ b/.claude/commands/release-now.md
@@ -151,6 +151,14 @@ Do NOT decide the version or mode on your own, do NOT edit the content without a
 
 ## Step 5 — Tag + Release
 
+BEFORE the tag, `gemini-extension.json`'s `"version"` must already read the confirmed version
+without its leading `v`. A tag is immutable: placed over a manifest still naming the previous
+release, it ships that stale number permanently, and `test_the_declared_version_keeps_up_with_the_public_releases`
+turns `main` red the moment the Release exists. Behind ⇒ STOP before tagging and say so — `main`
+takes a change only through a PR, so the one-line bump lands as its own PR (the user merges it),
+then this command runs again from Step 0 on the updated `main`. An RC tags a branch, so the bump
+belongs to that branch's own PR.
+
 After the user confirms the final version + content, `Write` the confirmed note to a file and pass
 that file to both commands — a multi-line markdown body handed to `-m`/`--notes` on a command line
 arrives mangled:

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "open-pr",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Review pull requests on GitHub, GitLab and Bitbucket across many stacks, learning each repo's own conventions over time and posting one review through that vendor's own CLI or REST API."
 }

--- a/src/commands/review.md
+++ b/src/commands/review.md
@@ -173,6 +173,11 @@ Step 9 `comments[]`. FORBIDDEN: a FILE finding inside `comments[]`.
 - the Context "Diff" is the sole source for the files it contains — never refetch it. An "Oversized
   paths" file is absent BY DESIGN; the guard above owns how it gets read
 - never read library source unless genuinely unsure
+- a conclusion that FLIPS on how a symbol outside the diff behaves — a caller of the new code, a
+  capability it assumes — takes 1 `Grep` for that symbol under `<worktree>` BEFORE concluding, raise
+  and stay-silent alike; max 3 per PR, never a full `Read`
+- that `Grep` inconclusive ⇒ raise it at 🔵 naming the symbol + the assumption. FORBIDDEN: asserting
+  the behaviour, or dropping it silently
 - never pad the count with trivia; there is no minimum N
 
 **Finding format** — every `<…>` is a placeholder to REPLACE, never to print, `<Fix>` being that word in

--- a/tests/budgets.json
+++ b/tests/budgets.json
@@ -4,19 +4,19 @@
     "review/known-repo-github-clean": 10474,
     "review/known-repo-gitlab-rereview": 14396,
     "review/large-diff-multistack": 12339,
-    "review/submodule-bump": 12522,
+    "review/submodule-bump": 12626,
     "review/agent-instructions-repo": 11179,
     "review/post-error-github": 10883,
-    "chat/reconfigure-review": 8000,
+    "chat/reconfigure-review": 8104,
     "upgrade": 2231,
     "clean": 1318,
     "review/known-repo-bitbucket-clean": 13213,
-    "review/known-repo-bitbucket-rereview": 15174,
+    "review/known-repo-bitbucket-rereview": 15278,
     "fix/known-repo-bitbucket": 10782,
     "fix/known-repo-github": 8403,
     "fix/first-run-gitlab": 9367,
     "feedback": 2175
   },
-  "mean": 9670,
+  "mean": 9735,
   "_note": "Ceilings measured by scripts/token_report.py (cl100k proxy); some are tightened by hand below that. --update-budgets rewrites EVERY ceiling to measured +2%, RAISING any that was tightened by hand \u2014 lower them by hand when a change wins tokens back."
 }

--- a/tests/test_prompt_graph.py
+++ b/tests/test_prompt_graph.py
@@ -530,6 +530,32 @@ def test_fix_suggestions_prefer_a_code_fence():
     assert "FORBIDDEN: prose when the" in step7, "prose must be the exception, not a sibling option"
 
 
+def test_a_cross_file_assumption_is_checked_before_it_is_concluded():
+    """A diff-scoped pass structurally cannot see whether the code around the diff agrees with
+    what the new code assumes — a caller invoking it the wrong way, a capability it takes for
+    granted. Scope carries the check, and all three parts of it are load-bearing:
+
+    the trigger is the conclusion FLIPPING on that symbol, not merely mentioning it, and it
+    binds the decision to stay silent as much as the decision to raise; the check is a bounded
+    `Grep`, because an unbounded one turns every review into a repo read; and an inconclusive
+    `Grep` still has to surface, or the rule quietly becomes permission to assume.
+    """
+    flat = " ".join(text(SRC / "commands" / "review.md").split())
+
+    assert "conclusion that FLIPS on how a symbol outside the diff behaves" in flat, \
+        "Scope must trigger on the conclusion flipping, not on any mention of an outside symbol"
+    assert "raise and stay-silent alike" in flat, \
+        "the check must bind the decision NOT to raise a finding too"
+    assert re.search(r"1 `Grep` for that symbol under `<worktree>` BEFORE concluding", flat), \
+        "the check must be a Grep aimed at the worktree, run before concluding"
+    assert re.search(r"max \d+ per PR, never a full `Read`", flat), \
+        "the Grep budget must be a number, and a full Read would defeat the cost argument"
+    assert re.search(r"`Grep` inconclusive ⇒ raise it at 🔵", flat), \
+        "an inconclusive Grep must still reach the PR, at the severity Scope names"
+    assert "FORBIDDEN: asserting the behaviour, or dropping it silently" in flat, \
+        "both ways out of an inconclusive Grep must stay closed"
+
+
 def test_chat_does_not_repeat_the_posted_findings():
     """The finding text is on the PR. Restating it in chat doubles the output for a reader
     who already has the better copy."""


### PR DESCRIPTION
Closes #94.

## What was missing

Nothing in `Scope` forbade looking outside the diff — `review.md:170` already called reading further "optional", and the one prohibition (`:175`) covers *library* source only. What was missing is a rule that ever *requires* the check, and any mention of `Grep`, which the command is already granted. So a review defaults to diff-only, and a caller invoking the new path the wrong way, or a capability the new code assumes, reads as clean.

## The rule

Two bullets in `Scope`:

- a conclusion that FLIPS on how a symbol outside the diff behaves takes 1 `Grep` for that symbol under `<worktree>` before concluding — binding the decision to stay silent as much as the decision to raise, max 3 per PR, never a full `Read`
- that `Grep` inconclusive ⇒ a 🔵 naming the symbol and the assumption. Asserting the behaviour, or dropping it silently, are both closed off

Trigger is the conclusion flipping, not "depends on", so it does not fire on every finding; the cap keeps a review from turning into a repo read. No pattern list to grow, per the issue's own rejection of one.

Owner is `review.md` `Scope` — the rule is about where the review may look. Not restated in `fix.md` or `review-criteria.md`.

## Context cost

+104 tokens per review scenario (+0.7% to +1.3%); `fix`, `upgrade`, `clean`, `feedback` unchanged. Three ceilings sat within ~100 tokens of measured and are now raised by hand by exactly that delta, so each keeps the headroom it had:

| scenario | ceiling | now |
|---|---|---|
| `review/submodule-bump` | 12522 | 12626 |
| `chat/reconfigure-review` | 8000 | 8104 |
| `review/known-repo-bitbucket-rereview` | 15174 | 15278 |
| mean | 9670 | 9735 |

## Second commit — release hygiene

`gemini-extension.json` still read `1.4.1` after `v1.4.2` was tagged, which is what `test_the_declared_version_keeps_up_with_the_public_releases` reports on `main` right now — red before this branch existed. Bumped here, and `/release-now` Step 5 now stops before tagging when the manifest is behind the confirmed version: a tag is immutable, so the bump has to land first, as its own PR.

## Test plan

- [x] `scripts/check.sh origin/main` — 80 passed, duplication scan clean
- [x] `test_a_cross_file_assumption_is_checked_before_it_is_concluded` pins all three parts of the rule (flip trigger, bounded `Grep` with a numeric cap, inconclusive path) so a later edit cannot silently drop one
- [ ] e2e not run — no fixture exercises a cross-file assumption yet; planting one is follow-up work