### PR TITLE
chore(release): declare 1.4.3 ahead of the tag

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "open-pr",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Review pull requests on GitHub, GitLab and Bitbucket across many stacks, learning each repo's own conventions over time and posting one review through that vendor's own CLI or REST API."
 }


### PR DESCRIPTION
One line: `gemini-extension.json` 1.4.2 → 1.4.3, landed before `v1.4.3` is tagged. A tag is immutable, so a manifest bumped afterwards leaves the released tree naming the previous version — the sequence `/release-now` Step 5 now requires.