### PR TITLE
chore(chart): context cost at v1.4.3

### DIFF
--- a/tests/token-history.json
+++ b/tests/token-history.json
@@ -112,6 +112,15 @@
       "upgrade": 2202,
       "clean": 1288,
       "feedback": 2126
+    },
+    {
+      "tag": "v1.4.3",
+      "date": "2026-08-27",
+      "review": 12096,
+      "fix": 9393,
+      "upgrade": 2202,
+      "clean": 1288,
+      "feedback": 2126
     }
   ]
 }

--- a/token-history.svg
+++ b/token-history.svg
@@ -20,74 +20,80 @@
 <line x1="62" y1="55.0" x2="702" y2="55.0" stroke="#8b949e" stroke-opacity="0.25"/>
 <text x="54" y="58.5" text-anchor="end" font-size="10" fill="#8b949e">18k</text>
 <text x="78.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.1.0</text>
-<text x="124.8" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.0</text>
-<text x="171.5" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.1</text>
-<text x="218.3" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.3.0</text>
-<text x="265.1" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.0.0</text>
-<text x="311.8" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.0</text>
-<text x="358.6" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.1</text>
-<text x="405.4" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.2</text>
-<text x="452.2" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.0</text>
-<text x="498.9" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.1</text>
-<text x="545.7" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.3.0</text>
-<text x="592.5" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.0</text>
-<text x="639.2" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.1</text>
-<text x="686.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.2</text>
-<polyline points="78.0,130.9 124.8,79.8 171.5,85.3 218.3,70.0 265.1,125.5 311.8,125.2 358.6,125.4 405.4,125.3 452.2,125.3 498.9,123.6 545.7,117.0 592.5,119.9 639.2,113.7 686.0,113.7" fill="none" stroke="#2f81f7" stroke-width="2" stroke-linejoin="round"/>
+<text x="121.4" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.0</text>
+<text x="164.9" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.2.1</text>
+<text x="208.3" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v0.3.0</text>
+<text x="251.7" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.0.0</text>
+<text x="295.1" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.0</text>
+<text x="338.6" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.1</text>
+<text x="382.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.1.2</text>
+<text x="425.4" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.0</text>
+<text x="468.9" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.2.1</text>
+<text x="512.3" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.3.0</text>
+<text x="555.7" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.0</text>
+<text x="599.1" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.1</text>
+<text x="642.6" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.2</text>
+<text x="686.0" y="249.0" text-anchor="middle" font-size="10" fill="#8b949e">v1.4.3</text>
+<polyline points="78.0,130.9 121.4,79.8 164.9,85.3 208.3,70.0 251.7,125.5 295.1,125.2 338.6,125.4 382.0,125.3 425.4,125.3 468.9,123.6 512.3,117.0 555.7,119.9 599.1,113.7 642.6,113.7 686.0,112.7" fill="none" stroke="#2f81f7" stroke-width="2" stroke-linejoin="round"/>
 <circle cx="78.0" cy="130.9" r="3" fill="#2f81f7"/>
-<circle cx="124.8" cy="79.8" r="3" fill="#2f81f7"/>
-<circle cx="171.5" cy="85.3" r="3" fill="#2f81f7"/>
-<circle cx="218.3" cy="70.0" r="3" fill="#2f81f7"/>
-<circle cx="265.1" cy="125.5" r="3" fill="#2f81f7"/>
-<circle cx="311.8" cy="125.2" r="3" fill="#2f81f7"/>
-<circle cx="358.6" cy="125.4" r="3" fill="#2f81f7"/>
-<circle cx="405.4" cy="125.3" r="3" fill="#2f81f7"/>
-<circle cx="452.2" cy="125.3" r="3" fill="#2f81f7"/>
-<circle cx="498.9" cy="123.6" r="3" fill="#2f81f7"/>
-<circle cx="545.7" cy="117.0" r="3" fill="#2f81f7"/>
-<circle cx="592.5" cy="119.9" r="3" fill="#2f81f7"/>
-<circle cx="639.2" cy="113.7" r="3" fill="#2f81f7"/>
-<circle cx="686.0" cy="113.7" r="3" fill="#2f81f7"/>
-<polyline points="218.3,101.6 265.1,147.1 311.8,147.1 358.6,145.7 405.4,145.7 452.2,145.7 498.9,144.0 545.7,137.3 592.5,139.1 639.2,139.1 686.0,139.2" fill="none" stroke="#e3742f" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="218.3" cy="101.6" r="3" fill="#e3742f"/>
-<circle cx="265.1" cy="147.1" r="3" fill="#e3742f"/>
-<circle cx="311.8" cy="147.1" r="3" fill="#e3742f"/>
-<circle cx="358.6" cy="145.7" r="3" fill="#e3742f"/>
-<circle cx="405.4" cy="145.7" r="3" fill="#e3742f"/>
-<circle cx="452.2" cy="145.7" r="3" fill="#e3742f"/>
-<circle cx="498.9" cy="144.0" r="3" fill="#e3742f"/>
-<circle cx="545.7" cy="137.3" r="3" fill="#e3742f"/>
-<circle cx="592.5" cy="139.1" r="3" fill="#e3742f"/>
-<circle cx="639.2" cy="139.1" r="3" fill="#e3742f"/>
+<circle cx="121.4" cy="79.8" r="3" fill="#2f81f7"/>
+<circle cx="164.9" cy="85.3" r="3" fill="#2f81f7"/>
+<circle cx="208.3" cy="70.0" r="3" fill="#2f81f7"/>
+<circle cx="251.7" cy="125.5" r="3" fill="#2f81f7"/>
+<circle cx="295.1" cy="125.2" r="3" fill="#2f81f7"/>
+<circle cx="338.6" cy="125.4" r="3" fill="#2f81f7"/>
+<circle cx="382.0" cy="125.3" r="3" fill="#2f81f7"/>
+<circle cx="425.4" cy="125.3" r="3" fill="#2f81f7"/>
+<circle cx="468.9" cy="123.6" r="3" fill="#2f81f7"/>
+<circle cx="512.3" cy="117.0" r="3" fill="#2f81f7"/>
+<circle cx="555.7" cy="119.9" r="3" fill="#2f81f7"/>
+<circle cx="599.1" cy="113.7" r="3" fill="#2f81f7"/>
+<circle cx="642.6" cy="113.7" r="3" fill="#2f81f7"/>
+<circle cx="686.0" cy="112.7" r="3" fill="#2f81f7"/>
+<polyline points="208.3,101.6 251.7,147.1 295.1,147.1 338.6,145.7 382.0,145.7 425.4,145.7 468.9,144.0 512.3,137.3 555.7,139.1 599.1,139.1 642.6,139.2 686.0,139.2" fill="none" stroke="#e3742f" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="208.3" cy="101.6" r="3" fill="#e3742f"/>
+<circle cx="251.7" cy="147.1" r="3" fill="#e3742f"/>
+<circle cx="295.1" cy="147.1" r="3" fill="#e3742f"/>
+<circle cx="338.6" cy="145.7" r="3" fill="#e3742f"/>
+<circle cx="382.0" cy="145.7" r="3" fill="#e3742f"/>
+<circle cx="425.4" cy="145.7" r="3" fill="#e3742f"/>
+<circle cx="468.9" cy="144.0" r="3" fill="#e3742f"/>
+<circle cx="512.3" cy="137.3" r="3" fill="#e3742f"/>
+<circle cx="555.7" cy="139.1" r="3" fill="#e3742f"/>
+<circle cx="599.1" cy="139.1" r="3" fill="#e3742f"/>
+<circle cx="642.6" cy="139.2" r="3" fill="#e3742f"/>
 <circle cx="686.0" cy="139.2" r="3" fill="#e3742f"/>
-<polyline points="265.1,210.5 311.8,210.5 358.6,210.5 405.4,210.5 452.2,210.5 498.9,209.4 545.7,209.4 592.5,209.4 639.2,209.4 686.0,209.5" fill="none" stroke="#a371f7" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="265.1" cy="210.5" r="3" fill="#a371f7"/>
-<circle cx="311.8" cy="210.5" r="3" fill="#a371f7"/>
-<circle cx="358.6" cy="210.5" r="3" fill="#a371f7"/>
-<circle cx="405.4" cy="210.5" r="3" fill="#a371f7"/>
-<circle cx="452.2" cy="210.5" r="3" fill="#a371f7"/>
-<circle cx="498.9" cy="209.4" r="3" fill="#a371f7"/>
-<circle cx="545.7" cy="209.4" r="3" fill="#a371f7"/>
-<circle cx="592.5" cy="209.4" r="3" fill="#a371f7"/>
-<circle cx="639.2" cy="209.4" r="3" fill="#a371f7"/>
+<polyline points="251.7,210.5 295.1,210.5 338.6,210.5 382.0,210.5 425.4,210.5 468.9,209.4 512.3,209.4 555.7,209.4 599.1,209.4 642.6,209.5 686.0,209.5" fill="none" stroke="#a371f7" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="251.7" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="295.1" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="338.6" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="382.0" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="425.4" cy="210.5" r="3" fill="#a371f7"/>
+<circle cx="468.9" cy="209.4" r="3" fill="#a371f7"/>
+<circle cx="512.3" cy="209.4" r="3" fill="#a371f7"/>
+<circle cx="555.7" cy="209.4" r="3" fill="#a371f7"/>
+<circle cx="599.1" cy="209.4" r="3" fill="#a371f7"/>
+<circle cx="642.6" cy="209.5" r="3" fill="#a371f7"/>
 <circle cx="686.0" cy="209.5" r="3" fill="#a371f7"/>
-<polyline points="311.8,219.6 358.6,219.5 405.4,219.5 452.2,219.5 498.9,218.3 545.7,218.3 592.5,218.3 639.2,218.3 686.0,218.4" fill="none" stroke="#3fb950" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="311.8" cy="219.6" r="3" fill="#3fb950"/>
-<circle cx="358.6" cy="219.5" r="3" fill="#3fb950"/>
-<circle cx="405.4" cy="219.5" r="3" fill="#3fb950"/>
-<circle cx="452.2" cy="219.5" r="3" fill="#3fb950"/>
-<circle cx="498.9" cy="218.3" r="3" fill="#3fb950"/>
-<circle cx="545.7" cy="218.3" r="3" fill="#3fb950"/>
-<circle cx="592.5" cy="218.3" r="3" fill="#3fb950"/>
-<circle cx="639.2" cy="218.3" r="3" fill="#3fb950"/>
+<polyline points="295.1,219.6 338.6,219.5 382.0,219.5 425.4,219.5 468.9,218.3 512.3,218.3 555.7,218.3 599.1,218.3 642.6,218.4 686.0,218.4" fill="none" stroke="#3fb950" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="295.1" cy="219.6" r="3" fill="#3fb950"/>
+<circle cx="338.6" cy="219.5" r="3" fill="#3fb950"/>
+<circle cx="382.0" cy="219.5" r="3" fill="#3fb950"/>
+<circle cx="425.4" cy="219.5" r="3" fill="#3fb950"/>
+<circle cx="468.9" cy="218.3" r="3" fill="#3fb950"/>
+<circle cx="512.3" cy="218.3" r="3" fill="#3fb950"/>
+<circle cx="555.7" cy="218.3" r="3" fill="#3fb950"/>
+<circle cx="599.1" cy="218.3" r="3" fill="#3fb950"/>
+<circle cx="642.6" cy="218.4" r="3" fill="#3fb950"/>
 <circle cx="686.0" cy="218.4" r="3" fill="#3fb950"/>
-<polyline points="545.7,210.7 592.5,210.7 639.2,210.1 686.0,210.2" fill="none" stroke="#db61a2" stroke-width="2" stroke-linejoin="round"/>
-<circle cx="545.7" cy="210.7" r="3" fill="#db61a2"/>
-<circle cx="592.5" cy="210.7" r="3" fill="#db61a2"/>
-<circle cx="639.2" cy="210.1" r="3" fill="#db61a2"/>
+<polyline points="512.3,210.7 555.7,210.7 599.1,210.1 642.6,210.2 686.0,210.2" fill="none" stroke="#db61a2" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="512.3" cy="210.7" r="3" fill="#db61a2"/>
+<circle cx="555.7" cy="210.7" r="3" fill="#db61a2"/>
+<circle cx="599.1" cy="210.1" r="3" fill="#db61a2"/>
+<circle cx="642.6" cy="210.2" r="3" fill="#db61a2"/>
 <circle cx="686.0" cy="210.2" r="3" fill="#db61a2"/>
 <circle cx="66" cy="18" r="3.5" fill="#2f81f7"/>
-<text x="75" y="21.5" font-size="11" fill="#8b949e">/open-pr:review 11,992</text>
+<text x="75" y="21.5" font-size="11" fill="#8b949e">/open-pr:review 12,096</text>
 <circle cx="246.0" cy="18" r="3.5" fill="#e3742f"/>
 <text x="255.0" y="21.5" font-size="11" fill="#8b949e">/open-pr:fix 9,393</text>
 <circle cx="398.0" cy="18" r="3.5" fill="#a371f7"/>


### PR DESCRIPTION
One point per release tag on the context-cost chart, measured at v1.4.3 by `scripts/token_chart.py --add`. The SVG is redrawn from those numbers, never hand-edited — the suite redraws it and compares.