### PR TITLE
docs(readme): lead with value, demo and install above the fold

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -6,7 +6,8 @@
 </p>
 
 <p align="center">
-  <strong>レビューは PR そのものに投稿されます</strong><br>
+  <strong>AI コードレビューを、ターミナルではなく PR 上に。</strong><br>
+  オープンソース · サーバー不要 · いま使っている agent CLI 上で動きます。<br>
   <sub><picture><source media="(prefers-color-scheme: dark)" srcset="./docs/images/icon/github-dark.png"><img src="./docs/images/icon/github.png" alt="" height="13"></picture>&nbsp;GitHub · <img src="./docs/images/icon/gitlab.png" alt="" height="13">&nbsp;GitLab · <img src="./docs/images/icon/bitbucket.png" alt="" height="13">&nbsp;Bitbucket</sub><br>
   <code>/open-pr:review</code> · <code>/open-pr:fix</code>
 </p>
@@ -31,31 +32,21 @@
   <a href="./README.vi-VN.md">Tiếng Việt</a> · <a href="./README.md">English</a> · <strong>日本語</strong> · <a href="./README.zh-Hans.md">简体中文</a>
 </p>
 
+AI コーディングで PR は速くなりました。レビューは速くなっていません。
+
+**`open-pr` はその最初のレビューラウンドを、ローカルではなく PR 上で実行します。** PR を開いた人なら誰でも、同じフィードバックを見られます。
+
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./docs/images/bottleneck/ja-dark.svg">
-    <img src="./docs/images/bottleneck/ja.svg" width="760" alt="AI 導入前: 1日 10 PR、レビューは追いつく。AI 導入後: 1日 30 PR、レビューがボトルネックになる。AI 導入後 + Open-pr: 1日 30 PR、Open-pr がレビューを速め、レビューは追いつく。">
-  </picture>
+  <a href="./docs/ja-JP/demo.md"><img src="./docs/images/review-demo-ja.png" width="680" alt="Overview、suggested change を含む行コメント、fix push 後の返信"></a>
 </p>
 
-AI コーディングの時代、PR の出る速さはレビューの速さを大きく上回っています。ボトルネックはもうコーディングではなく、**レビュー工程**にあります。レビュアーはプロジェクトの convention / security / performance を確認しつつ、ビジネスロジックもカバーしなければなりません — その頻度では、ほぼ持ちこたえられません。
+1 回の実行で、結びついた 3 つの要素が出ます: **overview**、**行コメント**（suggested change 付き）、そして `/open-pr:fix` が push したあとの **返信**。 — [デモを見る](./docs/ja-JP/demo.md)
 
-本当の問いはたいてい *「このコードは正しいか？」* ではなく、**開発者は送る前に PR をセルフレビューしたか**、それとも *"レビュアーがやってくれる"* と決めつけたか、です。それではレビュアーは AI の *vibecoding* ツールそのものです。
-
-ローカルでのレビューは信じにくい。誰でも *"レビュー済み"* と言えます。だから `open-pr` はそのステップを **remote** に移して可視化します — コメントは PR 上にあり、開いた人なら誰でも見られます。
-
-- `/open-pr:review <PR_URL>` → ちょうど **1** 件のレビュー（overview + 行コメント）
-- 開発者がコメントを読んで自分で直すか、`/open-pr:fix <PR_URL>` を使う（**1** コミット + スレッドごとの返信）
-- 毎回同じ手順: リポジトリの convention を読み、チームが PR で議論したことを記憶する
-
-> [!NOTE]
-> **レビューラウンド**（チームへの提案）:
-> 1. **Round 1** — 開発者が自分の PR で AI レビューを実行。レビューコメントがまだない → レビュアーは **差し戻し**、触れない。
-> 2. **Round 2** — レビュアーが再度実行（AI）。クリーン → **LGTM**。
-> 3. **Round 3** — レビュアーがドメイン部分をレビュー。
-
-> [!IMPORTANT]
-> AI はプロセス上の負荷を減らしますが、**最終責任はあなたにあります**。
+- 🔍 **1 回の実行でちょうど 1 件のレビュー** — bot コメントの垂れ流しではありません
+- 🧠 **リポジトリを学ぶ** — README / CLAUDE.md / AGENTS.md / docs / wiki を読み、**チームのルールが汎用ルールに優先**
+- 💬 **チームが言ったことを記憶** — ある PR での指摘が、次の実行に引き継がれます
+- 🔧 **`/open-pr:fix` は規律を守る** — ちょうど **1** コミット、force-push なし、スレッドごとに返信
+- 🔓 **オープンソース、サービス不要** — MIT、サーバーも bot アカウントも不要。いま使っている agent CLI 上で動きます
 
 ## インストール
 
@@ -74,13 +65,31 @@ curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/instal
 
 詳細ガイド: [インストール](./docs/ja-JP/install.md) · [ベンダーごとのトークン取得](./docs/ja-JP/credentials.md)。
 
-## 結果の見え方
+GitHub（`.../pull/<n>`）、GitLab（`.../-/merge_requests/<n>`、セルフホスト含む）、Bitbucket Cloud（`.../pull-requests/<n>`）に対応。
 
-1 回の実行で、結びついた 3 つの要素が出ます: **overview**、**行コメント**（suggested change 付き）、そして `/open-pr:fix` が push したあとの **返信**。
+## なぜレビューがボトルネックになるのか
 
-<a href="./docs/ja-JP/demo.md"><img src="./docs/images/review-demo-ja.png" width="680" alt="Overview、suggested change を含む行コメント、fix push 後の返信"></a>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./docs/images/bottleneck/ja-dark.svg">
+    <img src="./docs/images/bottleneck/ja.svg" width="760" alt="AI 導入前: 1日 10 PR、レビューは追いつく。AI 導入後: 1日 30 PR、レビューがボトルネックになる。AI 導入後 + Open-pr: 1日 30 PR、Open-pr がレビューを速め、レビューは追いつく。">
+  </picture>
+</p>
 
-[デモを見る](./docs/ja-JP/demo.md) · GitHub（`.../pull/<n>`）、GitLab（`.../-/merge_requests/<n>`、セルフホスト含む）、Bitbucket Cloud（`.../pull-requests/<n>`）に対応。
+AI コーディングの時代、PR の出る速さはレビューの速さを大きく上回っています。ボトルネックはもうコーディングではなく、**レビュー工程**にあります。レビュアーはプロジェクトの convention / security / performance を確認しつつ、ビジネスロジックもカバーしなければなりません — その頻度では、ほぼ持ちこたえられません。
+
+本当の問いはたいてい *「このコードは正しいか？」* ではなく、**開発者は送る前に PR をセルフレビューしたか**、それとも *"レビュアーがやってくれる"* と決めつけたか、です。それではレビュアーは AI の *vibecoding* ツールそのものです。
+
+ローカルでのレビューは信じにくい。誰でも *"レビュー済み"* と言えます。だから `open-pr` はそのステップを **remote** に移して可視化します — コメントは PR 上にあり、開いた人なら誰でも見られます。
+
+> [!NOTE]
+> **レビューラウンド**（チームへの提案）:
+> 1. **Round 1** — 開発者が自分の PR で AI レビューを実行。レビューコメントがまだない → レビュアーは **差し戻し**、触れない。
+> 2. **Round 2** — レビュアーが再度実行（AI）。クリーン → **LGTM**。
+> 3. **Round 3** — レビュアーがドメイン部分をレビュー。
+
+> [!IMPORTANT]
+> AI はプロセス上の負荷を減らしますが、**最終責任はあなたにあります**。
 
 ## 汎用レビュースキルとの違い
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 </p>
 
 <p align="center">
-  <strong>The review lands on the PR itself.</strong><br>
+  <strong>AI code review that lands on the PR — not in your terminal.</strong><br>
+  Open source · no server · runs in the agent CLI you already use.<br>
   <sub><picture><source media="(prefers-color-scheme: dark)" srcset="./docs/images/icon/github-dark.png"><img src="./docs/images/icon/github.png" alt="" height="13"></picture>&nbsp;GitHub · <img src="./docs/images/icon/gitlab.png" alt="" height="13">&nbsp;GitLab · <img src="./docs/images/icon/bitbucket.png" alt="" height="13">&nbsp;Bitbucket</sub><br>
   <code>/open-pr:review</code> · <code>/open-pr:fix</code>
 </p>
@@ -31,31 +32,21 @@
   <a href="./README.vi-VN.md">Tiếng Việt</a> · <strong>English</strong> · <a href="./README.ja-JP.md">日本語</a> · <a href="./README.zh-Hans.md">简体中文</a>
 </p>
 
+AI coding made PRs ship faster. Review did not get faster.
+
+**`open-pr` runs that first review round for you — on the PR, not on your laptop.** Anyone who opens the PR sees the same feedback.
+
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./docs/images/bottleneck/en-dark.svg">
-    <img src="./docs/images/bottleneck/en.svg" width="760" alt="Before AI: 10 PRs/day, review keeps up. After AI: 30 PRs/day, review is the bottleneck. After AI plus Open-pr: 30 PRs/day, Open-pr reviews faster and review keeps up.">
-  </picture>
+  <a href="./docs/demo.md"><img src="./docs/images/review-demo-en.png" width="680" alt="Overview, line comment with a suggested change, and the reply after the fix was pushed"></a>
 </p>
 
-In the age of AI coding, PRs ship far faster than they get reviewed. The bottleneck is no longer coding — it's **review**. Reviewers have to check the project's conventions / security / performance *and* cover business logic — and at that pace, almost nobody can keep up.
+One run produces three parts that belong together: an **overview**, **line comments** (with suggested changes), and a **reply** after `/open-pr:fix` has pushed. — [See the demo](./docs/demo.md)
 
-The real question usually isn't *"is this code correct?"*, but: **did the dev self-review the PR before sending it**, or just assume *"the reviewer will handle it"*? That makes the reviewer little more than a *vibecoding* tool for the AI.
-
-A local review is hard to trust. Anyone can say *"I already reviewed it"*. So `open-pr` moves that step to **remote** for transparency — comments sit on the PR, and anyone who opens it can see them.
-
-- `/open-pr:review <PR_URL>` → exactly **1** review (overview + line comments)
-- Dev reads the comments and fixes them, or uses `/open-pr:fix <PR_URL>` (**1** commit + a reply per thread)
-- Every run follows the same procedure: read the repo's conventions, remember what the team discussed on the PR
-
-> [!NOTE]
-> **Review rounds** (a suggestion for the team):
-> 1. **Round 1** — Dev runs AI review on the PR themselves. No review comments yet → reviewer **sends it back**, without touching it.
-> 2. **Round 2** — Reviewer runs it again (AI). Clean → **LGTM**.
-> 3. **Round 3** — Reviewer reviews the domain part.
-
-> [!IMPORTANT]
-> AI lightens the process load, but **final responsibility is still yours**.
+- 🔍 **Exactly 1 review per run** — one review posted, not a stream of bot comments
+- 🧠 **Learns your repo** — README / CLAUDE.md / AGENTS.md / docs / wiki; team rules beat generic rules
+- 💬 **Remembers what the team said** — a correction on one PR carries into the next run
+- 🔧 **`/open-pr:fix` is disciplined** — exactly **1** commit, no force-push, a reply on every thread
+- 🔓 **Open source, no service** — MIT, no server and no bot account; it runs in the agent CLI you already have
 
 ## Install
 
@@ -74,13 +65,31 @@ curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/instal
 
 Full guide: [Install](./docs/install.md) · [Getting a token per vendor](./docs/credentials.md).
 
-## What it looks like
+Works with GitHub (`.../pull/<n>`), GitLab (`.../-/merge_requests/<n>`, self-hosted included) and Bitbucket Cloud (`.../pull-requests/<n>`).
 
-One run produces three parts that belong together: an **overview**, **line comments** (with suggested changes), and a **reply** after `/open-pr:fix` has pushed.
+## Why review is the bottleneck
 
-<a href="./docs/demo.md"><img src="./docs/images/review-demo-en.png" width="680" alt="Overview, line comment with a suggested change, and the reply after the fix was pushed"></a>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./docs/images/bottleneck/en-dark.svg">
+    <img src="./docs/images/bottleneck/en.svg" width="760" alt="Before AI: 10 PRs/day, review keeps up. After AI: 30 PRs/day, review is the bottleneck. After AI plus Open-pr: 30 PRs/day, Open-pr reviews faster and review keeps up.">
+  </picture>
+</p>
 
-[See the demo](./docs/demo.md) · supports GitHub (`.../pull/<n>`), GitLab (`.../-/merge_requests/<n>`, self-hosted included) and Bitbucket Cloud (`.../pull-requests/<n>`).
+In the age of AI coding, PRs ship far faster than they get reviewed. The bottleneck is no longer coding — it's **review**. Reviewers have to check the project's conventions / security / performance *and* cover business logic — and at that pace, almost nobody can keep up.
+
+The real question usually isn't *"is this code correct?"*, but: **did the dev self-review the PR before sending it**, or just assume *"the reviewer will handle it"*? That makes the reviewer little more than a *vibecoding* tool for the AI.
+
+A local review is hard to trust. Anyone can say *"I already reviewed it"*. So `open-pr` moves that step to **remote** for transparency — comments sit on the PR, and anyone who opens it can see them.
+
+> [!NOTE]
+> **Review rounds** (a suggestion for the team):
+> 1. **Round 1** — Dev runs AI review on the PR themselves. No review comments yet → reviewer **sends it back**, without touching it.
+> 2. **Round 2** — Reviewer runs it again (AI). Clean → **LGTM**.
+> 3. **Round 3** — Reviewer reviews the domain part.
+
+> [!IMPORTANT]
+> AI lightens the process load, but **final responsibility is still yours**.
 
 ## How it differs from a generic review skill
 

--- a/README.vi-VN.md
+++ b/README.vi-VN.md
@@ -6,7 +6,8 @@
 </p>
 
 <p align="center">
-  <strong>Review đăng thẳng lên chính PR.</strong><br>
+  <strong>AI review code đăng thẳng lên PR — không nằm lại trong terminal.</strong><br>
+  Open source · không server · chạy ngay trong agent CLI bạn đang dùng.<br>
   <sub><picture><source media="(prefers-color-scheme: dark)" srcset="./docs/images/icon/github-dark.png"><img src="./docs/images/icon/github.png" alt="" height="13"></picture>&nbsp;GitHub · <img src="./docs/images/icon/gitlab.png" alt="" height="13">&nbsp;GitLab · <img src="./docs/images/icon/bitbucket.png" alt="" height="13">&nbsp;Bitbucket</sub><br>
   <code>/open-pr:review</code> · <code>/open-pr:fix</code>
 </p>
@@ -31,31 +32,21 @@
   <strong>Tiếng Việt</strong> · <a href="./README.md">English</a> · <a href="./README.ja-JP.md">日本語</a> · <a href="./README.zh-Hans.md">简体中文</a>
 </p>
 
+AI coding làm PR ra nhanh hơn. Còn review thì không nhanh hơn.
+
+**`open-pr` chạy vòng review đầu tiên đó cho bạn — trên chính PR, không phải trên máy bạn.** Ai mở PR cũng thấy cùng một feedback.
+
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./docs/images/bottleneck/vi-dark.svg">
-    <img src="./docs/images/bottleneck/vi.svg" width="760" alt="Trước AI: 10 PR/ngày, review theo kịp. Sau AI: 30 PR/ngày, review thành điểm nghẽn. Sau AI + Open-pr: 30 PR/ngày, Open-pr review nhanh hơn nên review theo kịp.">
-  </picture>
+  <a href="./docs/vi-VN/demo.md"><img src="./docs/images/review-demo-vi.png" width="680" alt="Overview, line comment kèm suggested change, và reply sau khi fix đã push"></a>
 </p>
 
-Trong thời buổi AI coding, PR ra nhanh hơn rất nhiều so với tốc độ review. Điểm nghẽn không còn nằm ở coding nữa mà nằm ở **khâu review**. Reviewer vừa phải check convention / security / performance dự án, vừa phải cover business logic — và với tần suất đó, gần như không kham nổi.
+Một lần chạy cho ra ba phần gắn với nhau: **overview**, **line comment** (kèm suggested change), và **reply** sau khi `/open-pr:fix` đã push. — [Xem demo](./docs/vi-VN/demo.md)
 
-Câu hỏi thật ra thường không phải *"code này đúng chưa?"*, mà là: **dev đã self-review PR trước khi gửi chưa**, hay cứ mặc định *"có reviewer lo"*? Điều này không khác gì reviewer chính là công cụ *vibecoding* cho AI.
-
-Nếu review ở local thì khó tin. Ai cũng có thể nói *"tôi review rồi"*. Vì vậy `open-pr` đưa bước đó lên **remote** để minh bạch — comment nằm ngay trên PR, ai vào cũng thấy.
-
-- `/open-pr:review <PR_URL>` → đúng **1** review (overview + line comment)
-- Dev đọc comment rồi tự fix, hoặc dùng `/open-pr:fix <PR_URL>` (**1** commit + reply từng thread)
-- Mỗi lần chạy cùng một procedure: đọc convention repo, tự ghi nhớ những gì team đã thảo luận trong PR
-
-> [!NOTE]
-> **Review rounds** (gợi ý cho team):
-> 1. **Round 1** — Dev tự chạy AI review trên PR. Chưa thấy comment review → reviewer **trả về**, chưa đụng vào.
-> 2. **Round 2** — Reviewer chạy lại (AI). Sạch → **LGTM**.
-> 3. **Round 3** — Reviewer review phần domain.
-
-> [!IMPORTANT]
-> AI giảm gánh nặng ở khâu quy trình, nhưng **trách nhiệm cuối cùng vẫn là bạn**.
+- 🔍 **Đúng 1 review mỗi lần chạy** — một review được đăng, không phải một dòng comment bot
+- 🧠 **Học convention của repo** — README / CLAUDE.md / AGENTS.md / docs / wiki; team rule thắng generic rule
+- 💬 **Nhớ những gì team đã nói** — một lần nhắc trên PR này được áp dụng cho lần chạy sau
+- 🔧 **`/open-pr:fix` có kỷ luật** — đúng **1** commit, không force-push, reply từng thread
+- 🔓 **Open source, không service** — MIT, không server, không bot account; chạy ngay trong agent CLI bạn đang dùng
 
 ## Cài đặt
 
@@ -74,13 +65,31 @@ curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/instal
 
 Hướng dẫn chi tiết: [Cài đặt](./docs/vi-VN/install.md) · [Lấy token cho từng vendor](./docs/vi-VN/credentials.md).
 
-## Kết quả trông như thế nào
+Hỗ trợ GitHub (`.../pull/<n>`), GitLab (`.../-/merge_requests/<n>`, kể cả self-hosted) và Bitbucket Cloud (`.../pull-requests/<n>`).
 
-Một lần chạy cho ra ba phần gắn với nhau: **overview**, **line comment** (kèm suggested change), và **reply** sau khi `/open-pr:fix` đã push.
+## Vì sao review thành điểm nghẽn
 
-<a href="./docs/vi-VN/demo.md"><img src="./docs/images/review-demo-vi.png" width="680" alt="Overview, line comment kèm suggested change, và reply sau khi fix đã push"></a>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./docs/images/bottleneck/vi-dark.svg">
+    <img src="./docs/images/bottleneck/vi.svg" width="760" alt="Trước AI: 10 PR/ngày, review theo kịp. Sau AI: 30 PR/ngày, review thành điểm nghẽn. Sau AI + Open-pr: 30 PR/ngày, Open-pr review nhanh hơn nên review theo kịp.">
+  </picture>
+</p>
 
-[Xem demo](./docs/vi-VN/demo.md) · hỗ trợ GitHub (`.../pull/<n>`), GitLab (`.../-/merge_requests/<n>`, kể cả self-hosted) và Bitbucket Cloud (`.../pull-requests/<n>`).
+Trong thời buổi AI coding, PR ra nhanh hơn rất nhiều so với tốc độ review. Điểm nghẽn không còn nằm ở coding nữa mà nằm ở **khâu review**. Reviewer vừa phải check convention / security / performance dự án, vừa phải cover business logic — và với tần suất đó, gần như không kham nổi.
+
+Câu hỏi thật ra thường không phải *"code này đúng chưa?"*, mà là: **dev đã self-review PR trước khi gửi chưa**, hay cứ mặc định *"có reviewer lo"*? Điều này không khác gì reviewer chính là công cụ *vibecoding* cho AI.
+
+Nếu review ở local thì khó tin. Ai cũng có thể nói *"tôi review rồi"*. Vì vậy `open-pr` đưa bước đó lên **remote** để minh bạch — comment nằm ngay trên PR, ai vào cũng thấy.
+
+> [!NOTE]
+> **Review rounds** (gợi ý cho team):
+> 1. **Round 1** — Dev tự chạy AI review trên PR. Chưa thấy comment review → reviewer **trả về**, chưa đụng vào.
+> 2. **Round 2** — Reviewer chạy lại (AI). Sạch → **LGTM**.
+> 3. **Round 3** — Reviewer review phần domain.
+
+> [!IMPORTANT]
+> AI giảm gánh nặng ở khâu quy trình, nhưng **trách nhiệm cuối cùng vẫn là bạn**.
 
 ## Khác gì so với skill review phổ thông
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -6,7 +6,8 @@
 </p>
 
 <p align="center">
-  <strong>评审直接发布在 PR 上</strong><br>
+  <strong>AI 代码评审直接落在 PR 上，而不是留在终端里。</strong><br>
+  开源 · 无需服务器 · 就跑在你已经在用的 agent CLI 里。<br>
   <sub><picture><source media="(prefers-color-scheme: dark)" srcset="./docs/images/icon/github-dark.png"><img src="./docs/images/icon/github.png" alt="" height="13"></picture>&nbsp;GitHub · <img src="./docs/images/icon/gitlab.png" alt="" height="13">&nbsp;GitLab · <img src="./docs/images/icon/bitbucket.png" alt="" height="13">&nbsp;Bitbucket</sub><br>
   <code>/open-pr:review</code> · <code>/open-pr:fix</code>
 </p>
@@ -31,31 +32,21 @@
   <a href="./README.vi-VN.md">Tiếng Việt</a> · <a href="./README.md">English</a> · <a href="./README.ja-JP.md">日本語</a> · <strong>简体中文</strong>
 </p>
 
+AI 编码让 PR 变快了，评审并没有变快。
+
+**`open-pr` 把第一轮评审跑在 PR 上，而不是你的本地。** 任何打开这个 PR 的人，看到的都是同一份反馈。
+
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./docs/images/bottleneck/zh-dark.svg">
-    <img src="./docs/images/bottleneck/zh.svg" width="760" alt="AI 之前：每天 10 个 PR，评审跟得上。AI 之后：每天 30 个 PR，评审成为瓶颈。AI 之后 + Open-pr：每天 30 个 PR，Open-pr 让评审更快，评审跟得上。">
-  </picture>
+  <a href="./docs/zh-Hans/demo.md"><img src="./docs/images/review-demo-en.png" width="680" alt="总览、带 suggested change 的行级评论，以及 fix 推送后的回复"></a>
 </p>
 
-在 AI 编码的时代，PR 提交的速度远远快过评审的速度。瓶颈已经不在写代码，而在 **评审**。评审者既要检查项目规范 / 安全 / 性能，*还要* 覆盖业务逻辑 —— 以这样的节奏，几乎没有人跟得上。
+一次运行会产出三个互相关联的部分：**总览**、**行级评论**（附带 suggested change），以及 `/open-pr:fix` 推送之后的 **回复**。 —— [查看演示](./docs/zh-Hans/demo.md)
 
-真正的问题往往不是 *"这段代码对不对？"*，而是：**开发者在发出 PR 之前，自己评审过吗**，还是想着 *"评审者会处理的"*？这样一来，评审者不过是 AI 的一个 *vibecoding* 工具而已。
-
-本地评审很难取信于人。谁都可以说 *"我已经审过了"*。所以 `open-pr` 把这一步搬到 **远端**，让它透明 —— 评论就留在 PR 上，任何打开这个 PR 的人都看得见。
-
-- `/open-pr:review <PR_URL>` → 恰好 **1** 条评审（总览 + 行级评论）
-- 开发者读评论并修复，或者用 `/open-pr:fix <PR_URL>`（**1** 个 commit + 每个 thread 一条回复）
-- 每次运行都走同一套流程：读取仓库的规范，记住团队在 PR 上讨论过的内容
-
-> [!NOTE]
-> **评审轮次**（给团队的一个建议）：
-> 1. **第 1 轮** —— 开发者自己在 PR 上跑一次 AI 评审。还没有评审评论 → 评审者 **直接退回**，不去碰它。
-> 2. **第 2 轮** —— 评审者再跑一次（AI）。干净 → **LGTM**。
-> 3. **第 3 轮** —— 评审者评审业务领域的部分。
-
-> [!IMPORTANT]
-> AI 减轻的是流程负担，但 **最终责任仍然在你身上**。
+- 🔍 **每次运行恰好 1 条评审** —— 只发一条，不是源源不断的 bot 评论
+- 🧠 **学习你的仓库** —— 读 README / CLAUDE.md / AGENTS.md / docs / wiki；**团队规范优先于通用规则**
+- 💬 **记住团队说过的话** —— 这次 PR 上的一句纠正，下次运行就会应用
+- 🔧 **`/open-pr:fix` 有纪律** —— 恰好 **1** 个 commit，不 force-push，每个 thread 一条回复
+- 🔓 **开源，无需服务** —— MIT，不需要服务器、也不需要 bot 账号；就跑在你已经在用的 agent CLI 里
 
 ## 安装
 
@@ -74,13 +65,31 @@ curl -fsSL https://raw.githubusercontent.com/TOMOSIA-VIETNAM/open-pr/main/instal
 
 完整指南：[安装](./docs/zh-Hans/install.md) · [各平台如何取得 token](./docs/zh-Hans/credentials.md)。
 
-## 实际效果
+支持 GitHub（`.../pull/<n>`）、GitLab（`.../-/merge_requests/<n>`，含自建实例）和 Bitbucket Cloud（`.../pull-requests/<n>`）。
 
-一次运行会产出三个互相关联的部分：**总览**、**行级评论**（附带 suggested change），以及 `/open-pr:fix` 推送之后的 **回复**。
+## 为什么评审成了瓶颈
 
-<a href="./docs/zh-Hans/demo.md"><img src="./docs/images/review-demo-en.png" width="680" alt="总览、带 suggested change 的行级评论，以及 fix 推送后的回复"></a>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./docs/images/bottleneck/zh-dark.svg">
+    <img src="./docs/images/bottleneck/zh.svg" width="760" alt="AI 之前：每天 10 个 PR，评审跟得上。AI 之后：每天 30 个 PR，评审成为瓶颈。AI 之后 + Open-pr：每天 30 个 PR，Open-pr 让评审更快，评审跟得上。">
+  </picture>
+</p>
 
-[查看演示](./docs/zh-Hans/demo.md) · 支持 GitHub（`.../pull/<n>`）、GitLab（`.../-/merge_requests/<n>`，含自建实例）和 Bitbucket Cloud（`.../pull-requests/<n>`）。
+在 AI 编码的时代，PR 提交的速度远远快过评审的速度。瓶颈已经不在写代码，而在 **评审**。评审者既要检查项目规范 / 安全 / 性能，*还要* 覆盖业务逻辑 —— 以这样的节奏，几乎没有人跟得上。
+
+真正的问题往往不是 *"这段代码对不对？"*，而是：**开发者在发出 PR 之前，自己评审过吗**，还是想着 *"评审者会处理的"*？这样一来，评审者不过是 AI 的一个 *vibecoding* 工具而已。
+
+本地评审很难取信于人。谁都可以说 *"我已经审过了"*。所以 `open-pr` 把这一步搬到 **远端**，让它透明 —— 评论就留在 PR 上，任何打开这个 PR 的人都看得见。
+
+> [!NOTE]
+> **评审轮次**（给团队的一个建议）：
+> 1. **第 1 轮** —— 开发者自己在 PR 上跑一次 AI 评审。还没有评审评论 → 评审者 **直接退回**，不去碰它。
+> 2. **第 2 轮** —— 评审者再跑一次（AI）。干净 → **LGTM**。
+> 3. **第 3 轮** —— 评审者评审业务领域的部分。
+
+> [!IMPORTANT]
+> AI 减轻的是流程负担，但 **最终责任仍然在你身上**。
 
 ## 与普通评审 skill 的差别
 


### PR DESCRIPTION
Reorder the first ~50 lines of all four READMEs so a first-time visitor reaches the product before the argument for it:

  value prop -> positioning -> problem -> demo -> benefits -> install

The demo screenshot and the Install section move up from the middle of the page; the bottleneck chart and the three problem paragraphs move down into a section now named for what it holds, "Why review is the bottleneck", so it no longer competes with "How it differs from a generic review skill" for the same question.

Also:
- add the open-source / no-server / runs-in-your-agent-CLI line to the header, where it is a selling point rather than a footnote
- rewrite the fold bullets so each carries one distinct differentiator instead of restating the image caption
- say "no force-push" rather than "no history rewriting", matching the guarantee the plugin actually makes
- split the vendor URL patterns off the Install links line

No content is dropped: the bottleneck chart, the problem paragraphs, the review-rounds note, the comparison table, the flow diagram and the command reference are all still here, lower down.

## Description

<!-- What changed, and why it needed to change. -->

## Type of change

- [ ] 🔴 Breaking change (changes config/output behavior that repos using the plugin depend on)
- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📝 Docs (README/CLAUDE.md, no runtime behavior change)
- [ ] 🔧 Chore (refactor, tooling, no user-visible behavior change)

## How was this tested

<!--
`scripts/check.sh <base-ref>` is the floor: the suite, the duplication scan, the context-cost
report. It proves the graph still holds, not that the agent behaves — for that, install the plugin
(./scripts/reinstall.sh) and call /open-pr:review <PR_URL> on a real PR, or run the e2e fixture
(e2e/bootstrap.sh --pr <n>). Paste the PR you dogfooded against, or say how else you verified it.
-->

## Checklist

- [ ] `scripts/check.sh <base-ref>` passes — suite, duplication scan, context cost
- [ ] Context cost: cheaper → lower ceilings; costlier for a correct fix → PR says which
  scenario, by how much, and why. Never strip behaviour for budget
  (`--update-budgets` rewrites every ceiling to measured +2% — fine when none were hand-tightened)
- [ ] `tests/token-history.json` and `token-history.svg` untouched — the chart takes one frozen
  point per release (`/release-now`), never one per PR
- [ ] Behavior/architecture change → updated `CLAUDE.md` accordingly
- [ ] Anything a user sees — a command, the flow, a default, what setup asks — → every README
  version (`README.md` and each `README.<lang>.md`) and the page that owns the detail in `docs/`
  and each `docs/<lang>/`. No page left describing the old behavior
- [ ] Added a config field → classified in `src/reference/settings-schema.md`, read-time default in
  `src/core/repo-settings.md`, asked in `src/setup/bootstrap.md`
- [ ] Changed the config shape an EXISTING repo already has (renamed, removed, restructured) →
  `llm-upgrades/vN.md` + its line in `llm-upgrades/index.md` + the checkpoint in
  `src/core/llm-upgrades-index.md`. A new field with a read-time default needs no migration
- [ ] No new `allowed-tools` grant is broader than necessary (e.g. a blanket `gh api:*`) — the PR
  content being reviewed is untrusted data
