### PR TITLE
docs(readme): make the vendor CLI login an explicit install step

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -50,7 +50,18 @@ AI コーディングで PR は速くなりました。でもレビューは速�
 
 ## インストール
 
-[Claude Code](https://claude.ai/code):
+**1. ベンダーの CLI にログイン。** プラグイン自体は credential を持たず、*あなたの*アカウントで PR を読み、レビューを投稿します:
+
+```bash
+# GitHub
+brew install gh          # または https://cli.github.com/
+gh auth login            # GitHub.com → HTTPS → Login with a web browser
+gh auth status           # "Logged in to github.com as <you>" と出れば OK
+```
+
+GitLab は `brew install glab && glab auth login --hostname gitlab.com`。Bitbucket に CLI はなく、環境変数 `BITBUCKET_EMAIL` + `BITBUCKET_API_TOKEN` を読みます。最小権限と確認方法: [ベンダーごとのトークン取得](./docs/ja-JP/credentials.md)。
+
+**2. プラグイン。** [Claude Code](https://claude.ai/code):
 
 ```bash
 /plugin marketplace add TOMOSIA-VIETNAM/open-pr

--- a/README.md
+++ b/README.md
@@ -50,7 +50,18 @@ One run produces three parts that belong together: an **overview**, **line comme
 
 ## Install
 
-[Claude Code](https://claude.ai/code):
+**1. A vendor CLI, logged in.** The plugin carries no credential of its own — it reads the PR and posts the review through *your* account:
+
+```bash
+# GitHub
+brew install gh          # or https://cli.github.com/
+gh auth login            # GitHub.com → HTTPS → Login with a web browser
+gh auth status           # must say "Logged in to github.com as <you>"
+```
+
+GitLab: `brew install glab && glab auth login --hostname gitlab.com`. Bitbucket ships no CLI — it reads `BITBUCKET_EMAIL` + `BITBUCKET_API_TOKEN` from the environment. Minimum permissions and how to check them: [Getting a token per vendor](./docs/credentials.md).
+
+**2. The plugin.** [Claude Code](https://claude.ai/code):
 
 ```bash
 /plugin marketplace add TOMOSIA-VIETNAM/open-pr

--- a/README.vi-VN.md
+++ b/README.vi-VN.md
@@ -50,7 +50,18 @@ Một lần chạy cho ra ba phần gắn với nhau: **overview**, **line comme
 
 ## Cài đặt
 
-[Claude Code](https://claude.ai/code):
+**1. CLI của vendor, đã đăng nhập.** Plugin không giữ credential riêng — nó đọc PR và post review bằng tài khoản *của bạn*:
+
+```bash
+# GitHub
+brew install gh          # hoặc https://cli.github.com/
+gh auth login            # GitHub.com → HTTPS → Login with a web browser
+gh auth status           # phải hiện "Logged in to github.com as <bạn>"
+```
+
+GitLab: `brew install glab && glab auth login --hostname gitlab.com`. Bitbucket không có CLI — nó đọc `BITBUCKET_EMAIL` + `BITBUCKET_API_TOKEN` từ environment. Quyền tối thiểu và cách tự kiểm tra: [Lấy token cho từng vendor](./docs/vi-VN/credentials.md).
+
+**2. Plugin.** [Claude Code](https://claude.ai/code):
 
 ```bash
 /plugin marketplace add TOMOSIA-VIETNAM/open-pr

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -50,7 +50,18 @@ AI 编码让 PR 变快了。但评审并没有变快。
 
 ## 安装
 
-[Claude Code](https://claude.ai/code)：
+**1. 先登录对应平台的 CLI。** 插件本身不持有任何 credential —— 它用*你的*账号读取 PR、发表评审：
+
+```bash
+# GitHub
+brew install gh          # 或 https://cli.github.com/
+gh auth login            # GitHub.com → HTTPS → Login with a web browser
+gh auth status           # 应显示 "Logged in to github.com as <you>"
+```
+
+GitLab：`brew install glab && glab auth login --hostname gitlab.com`。Bitbucket 没有 CLI —— 它从环境变量读取 `BITBUCKET_EMAIL` + `BITBUCKET_API_TOKEN`。各平台的最小权限与自查方法：[各平台如何取得 token](./docs/zh-Hans/credentials.md)。
+
+**2. 插件。** [Claude Code](https://claude.ai/code)：
 
 ```bash
 /plugin marketplace add TOMOSIA-VIETNAM/open-pr


### PR DESCRIPTION
## Description

The Install section jumped straight to the plugin, leaving `gh auth login` (and its GitLab / Bitbucket equivalents) only in `docs/credentials.md`. A first-time reader installs the plugin, runs a review and hits an auth error before learning the CLI was a prerequisite.

The section is now numbered: step 1 is the vendor CLI logged in — the three GitHub commands inline (`brew install gh`, `gh auth login`, `gh auth status`), plus one line each for GitLab (`glab auth login --hostname`) and Bitbucket (no CLI, `BITBUCKET_EMAIL` + `BITBUCKET_API_TOKEN`) — and step 2 is the plugin install as before.

Same change in all four language READMEs, each linking its own credentials page.

## Type of change

- [ ] 🔴 Breaking change (changes config/output behavior that repos using the plugin depend on)
- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [x] 📝 Docs (README/CLAUDE.md, no runtime behavior change)
- [ ] 🔧 Chore (refactor, tooling, no user-visible behavior change)

## How was this tested

Nothing under `src/` changed — no prompt, command, config field or vendor entry is touched, so the graph, the duplication scan and the context cost are all unaffected. Verified by reading the rendered Install section in each of the four READMEs and confirming every relative link resolves (`docs/credentials.md`, `docs/vi-VN/credentials.md`, `docs/ja-JP/credentials.md`, `docs/zh-Hans/credentials.md` all exist).

The commands themselves are the ones already documented in `docs/credentials.md`, unchanged.

## Checklist

- [ ] `scripts/check.sh <base-ref>` passes — suite, duplication scan, context cost
  <!-- Not run: the diff is README prose only, no file under src/ -->
- [x] Context cost: unchanged — no agent-read file in the diff
- [x] `tests/token-history.json` and `token-history.svg` untouched
- [x] Behavior/architecture change → n/a, no behavior change
- [x] Anything a user sees → all four README versions updated; `docs/install.md` and
  `docs/credentials.md` already carried this requirement and still own the detail
- [x] Added a config field → n/a
- [x] Changed the config shape an EXISTING repo already has → n/a
- [x] No new `allowed-tools` grant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
