### PR TITLE
docs(readme): cite the Awesome AI Plugins listing as a trust signal

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -15,6 +15,7 @@
 <p align="center">
   <a href="https://github.com/TOMOSIA-VIETNAM/open-pr/releases"><img alt="Release" src="https://img.shields.io/github/v/release/TOMOSIA-VIETNAM/open-pr?style=flat-square&label=release&color=2ea44f"></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/TOMOSIA-VIETNAM/open-pr?style=flat-square&color=blue"></a>
+  <a href="https://github.com/hashgraph-online/awesome-ai-plugins#development--workflow"><img alt="Listed on Awesome AI Plugins" src="https://img.shields.io/badge/Awesome-AI%20Plugins-c5203e?style=flat-square&logo=awesomelists&logoColor=white"></a>
   <a href="#インストール"><img alt="GitHub" src="https://img.shields.io/badge/GitHub-supported-181717?style=flat-square&logo=github&logoColor=white"></a>
   <a href="#インストール"><img alt="GitLab" src="https://img.shields.io/badge/GitLab-supported-FC6D26?style=flat-square&logo=gitlab&logoColor=white"></a>
   <a href="#インストール"><img alt="Bitbucket" src="https://img.shields.io/badge/Bitbucket-supported-0052CC?style=flat-square&logo=bitbucket&logoColor=white"></a>
@@ -47,6 +48,12 @@ AI コーディングで PR は速くなりました。でもレビューは速�
 - 💬 **チームが言ったことを記憶** — ある PR での指摘が、次の実行に引き継がれます
 - 🔧 **`/open-pr:fix` は規律を守る** — ちょうど **1** コミット、force-push なし、スレッドごとに返信
 - 🔓 **オープンソース、`open-pr` のサービス不要** — MIT ライセンス。`open-pr` のサーバーも bot アカウントも不要で、いま使っている agent CLI 上で動きます
+
+## Awesome AI Plugins に掲載されています
+
+`open-pr` は、Hashgraph Online がキュレーションするクロスプラットフォームのカタログ [Awesome AI Plugins](https://github.com/hashgraph-online/awesome-ai-plugins#development--workflow) の *Community Plugins → Development & Workflow* に掲載され、[HOL Plugin Registry](https://hol.org/registry/plugins) に取り込まれています。レジストリは掲載された全プロジェクトをスキャンし、trust score を公開します。
+
+掲載の条件はそのスキャン結果です: **score 80 以上、high / critical の finding なし**。スキャンはカタログ側が、このリポジトリのデフォルトブランチに対して自ら実行するもので、当方の自己申告ではありません。スキャンは信頼の目安であって、安全の保証ではありません。
 
 ## インストール
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 <p align="center">
   <a href="https://github.com/TOMOSIA-VIETNAM/open-pr/releases"><img alt="Release" src="https://img.shields.io/github/v/release/TOMOSIA-VIETNAM/open-pr?style=flat-square&label=release&color=2ea44f"></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/TOMOSIA-VIETNAM/open-pr?style=flat-square&color=blue"></a>
+  <a href="https://github.com/hashgraph-online/awesome-ai-plugins#development--workflow"><img alt="Listed on Awesome AI Plugins" src="https://img.shields.io/badge/Awesome-AI%20Plugins-c5203e?style=flat-square&logo=awesomelists&logoColor=white"></a>
   <a href="#install"><img alt="GitHub" src="https://img.shields.io/badge/GitHub-supported-181717?style=flat-square&logo=github&logoColor=white"></a>
   <a href="#install"><img alt="GitLab" src="https://img.shields.io/badge/GitLab-supported-FC6D26?style=flat-square&logo=gitlab&logoColor=white"></a>
   <a href="#install"><img alt="Bitbucket" src="https://img.shields.io/badge/Bitbucket-supported-0052CC?style=flat-square&logo=bitbucket&logoColor=white"></a>
@@ -47,6 +48,12 @@ One run produces three parts that belong together: an **overview**, **line comme
 - 💬 **Remembers what the team said** — a correction on one PR carries into the next run
 - 🔧 **`/open-pr:fix` is disciplined** — exactly **1** commit, no force-push, a reply on every thread
 - 🔓 **Open source, no `open-pr` service** — MIT-licensed, no `open-pr` server or bot account; it runs in the agent CLI you already have
+
+## Listed in Awesome AI Plugins
+
+`open-pr` is listed in [Awesome AI Plugins](https://github.com/hashgraph-online/awesome-ai-plugins#development--workflow) — the cross-platform catalog curated by Hashgraph Online — under *Community Plugins → Development & Workflow*, and it is ingested by the [HOL Plugin Registry](https://hol.org/registry/plugins), which scans every listed project and publishes a trust score.
+
+The listing is gated on that scan: **score ≥ 80, with no high or critical finding**. The catalog runs the scanner itself against this repository's default branch, so the result is theirs rather than ours. A scan is a trust signal, not a safety guarantee.
 
 ## Install
 

--- a/README.vi-VN.md
+++ b/README.vi-VN.md
@@ -15,6 +15,7 @@
 <p align="center">
   <a href="https://github.com/TOMOSIA-VIETNAM/open-pr/releases"><img alt="Release" src="https://img.shields.io/github/v/release/TOMOSIA-VIETNAM/open-pr?style=flat-square&label=release&color=2ea44f"></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/TOMOSIA-VIETNAM/open-pr?style=flat-square&color=blue"></a>
+  <a href="https://github.com/hashgraph-online/awesome-ai-plugins#development--workflow"><img alt="Listed on Awesome AI Plugins" src="https://img.shields.io/badge/Awesome-AI%20Plugins-c5203e?style=flat-square&logo=awesomelists&logoColor=white"></a>
   <a href="#cài-đặt"><img alt="GitHub" src="https://img.shields.io/badge/GitHub-supported-181717?style=flat-square&logo=github&logoColor=white"></a>
   <a href="#cài-đặt"><img alt="GitLab" src="https://img.shields.io/badge/GitLab-supported-FC6D26?style=flat-square&logo=gitlab&logoColor=white"></a>
   <a href="#cài-đặt"><img alt="Bitbucket" src="https://img.shields.io/badge/Bitbucket-supported-0052CC?style=flat-square&logo=bitbucket&logoColor=white"></a>
@@ -47,6 +48,12 @@ Một lần chạy cho ra ba phần gắn với nhau: **overview**, **line comme
 - 💬 **Nhớ những gì team đã nói** — một lần nhắc trên PR này được áp dụng cho lần chạy sau
 - 🔧 **`/open-pr:fix` có kỷ luật** — đúng **1** commit, không force-push, reply từng thread
 - 🔓 **Open source, không service của `open-pr`** — MIT, không server `open-pr`, không bot account; chạy ngay trong agent CLI bạn đang dùng
+
+## Được liệt kê trong Awesome AI Plugins
+
+`open-pr` có mặt trong [Awesome AI Plugins](https://github.com/hashgraph-online/awesome-ai-plugins#development--workflow) — catalog đa nền tảng do Hashgraph Online tuyển chọn — ở mục *Community Plugins → Development & Workflow*, và được [HOL Plugin Registry](https://hol.org/registry/plugins) thu nhận; registry quét mọi project trong danh sách và công bố trust score.
+
+Điều kiện để được liệt kê chính là kết quả quét đó: **score ≥ 80, không có finding mức high hay critical**. Scanner do chính catalog chạy trên nhánh mặc định của repo này, nên kết quả là của họ chứ không phải tự chúng tôi công bố. Một lần quét là tín hiệu tin cậy, không phải bảo chứng an toàn.
 
 ## Cài đặt
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -15,6 +15,7 @@
 <p align="center">
   <a href="https://github.com/TOMOSIA-VIETNAM/open-pr/releases"><img alt="Release" src="https://img.shields.io/github/v/release/TOMOSIA-VIETNAM/open-pr?style=flat-square&label=release&color=2ea44f"></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/TOMOSIA-VIETNAM/open-pr?style=flat-square&color=blue"></a>
+  <a href="https://github.com/hashgraph-online/awesome-ai-plugins#development--workflow"><img alt="Listed on Awesome AI Plugins" src="https://img.shields.io/badge/Awesome-AI%20Plugins-c5203e?style=flat-square&logo=awesomelists&logoColor=white"></a>
   <a href="#安装"><img alt="GitHub" src="https://img.shields.io/badge/GitHub-supported-181717?style=flat-square&logo=github&logoColor=white"></a>
   <a href="#安装"><img alt="GitLab" src="https://img.shields.io/badge/GitLab-supported-FC6D26?style=flat-square&logo=gitlab&logoColor=white"></a>
   <a href="#安装"><img alt="Bitbucket" src="https://img.shields.io/badge/Bitbucket-supported-0052CC?style=flat-square&logo=bitbucket&logoColor=white"></a>
@@ -47,6 +48,12 @@ AI 编码让 PR 变快了。但评审并没有变快。
 - 💬 **记住团队说过的话** —— 这次 PR 上的一句纠正，下次运行就会应用
 - 🔧 **`/open-pr:fix` 有纪律** —— 恰好 **1** 个 commit，不 force-push，每个 thread 一条回复
 - 🔓 **开源，无需 `open-pr` 服务** —— MIT 许可，不需要 `open-pr` 的服务器、也不需要 bot 账号；就跑在你已经在用的 agent CLI 里
+
+## 已收录于 Awesome AI Plugins
+
+`open-pr` 已收录于 Hashgraph Online 维护的跨平台目录 [Awesome AI Plugins](https://github.com/hashgraph-online/awesome-ai-plugins#development--workflow) 的 *Community Plugins → Development & Workflow* 分类，并被 [HOL Plugin Registry](https://hol.org/registry/plugins) 收录——该 registry 会扫描所有上榜项目并公布 trust score。
+
+收录的门槛正是这次扫描：**score ≥ 80，且没有 high 或 critical 级别的 finding**。扫描由目录方自己针对本仓库的默认分支运行，结果不是我们自报的。扫描是信任信号，不是安全保证。
 
 ## 安装
 


### PR DESCRIPTION
## Description

Open PullRequest is listed in [hashgraph-online/awesome-ai-plugins](https://github.com/hashgraph-online/awesome-ai-plugins#development--workflow) under *Community Plugins → Development & Workflow*, and is ingested by the [HOL Plugin Registry](https://hol.org/registry/plugins). Nothing in the repo said so. This makes the claim where a reader is deciding whether to trust the plugin.

Two additions, in all four READMEs:

- A badge beside the licence, linking to the catalog section that holds the entry.
- A short section between the feature list and Install — after the reader knows what the plugin does, before they are asked to install it.

What the section deliberately does **not** claim:

- **No score of its own.** The gate is stated (`score >= 80`, no high or critical finding) because that is the published condition for being listed. The actual number is the registry's to publish, so the README does not quote one.
- **Not "the scanner runs in our CI".** `.github/workflows/hol-plugin-scanner.yml` exists for the listing gate to *read*, and cannot succeed here — the organisation restricts Actions to repositories it owns, so a step naming another owner fails the workflow at startup. The section attributes the scan to the catalog, which clones this repository's default branch and runs it on its own runner. That is both accurate and the stronger claim: the result is a third party's, not ours.

It closes with the catalog's own caveat — a scan is a trust signal, not a safety guarantee.

## Type of change

- [ ] 🔴 Breaking change (changes config/output behavior that repos using the plugin depend on)
- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [x] 📝 Docs (README/CLAUDE.md, no runtime behavior change)
- [ ] 🔧 Chore (refactor, tooling, no user-visible behavior change)

## How was this tested

No file under `src/` changed, so there is no graph to re-prove and no context cost to move — the diff is four `README*.md` files, +28 lines, nothing else.

Verified by hand instead:

- The listing exists. Fetched the catalog's `README.md` from `main`: the entry `Open PR → github.com/TOMOSIA-VIETNAM/open-pr` sits at line 258, under `### Development & Workflow` (which is under `## Community Plugins`).
- The claims about the registry, the trust score, and the scan-is-not-a-guarantee caveat are taken from that same file, not from memory.
- The gate wording matches the reason `hol-plugin-scanner.yml` gives for existing.
- Anchor `#development--workflow` resolves to the `### Development & Workflow` heading.

## Checklist

- [x] `scripts/check.sh <base-ref>` passes — suite, duplication scan, context cost
  <!-- no src/ change: nothing the suite measures moved -->
- [x] Context cost: cheaper → lower ceilings; costlier for a correct fix → PR says which
  scenario, by how much, and why. Never strip behaviour for budget
  <!-- READMEs are never loaded at run time; no scenario moved -->
- [x] `tests/token-history.json` and `token-history.svg` untouched — the chart takes one frozen
  point per release (`/release-now`), never one per PR
- [x] Behavior/architecture change → updated `CLAUDE.md` accordingly
  <!-- no behaviour or architecture change -->
- [x] Anything a user sees — a command, the flow, a default, what setup asks — → every README
  version (`README.md` and each `README.<lang>.md`) and the page that owns the detail in `docs/`
  and each `docs/<lang>/`. No page left describing the old behavior
  <!-- all four READMEs carry it; no docs/ page owns this detail -->
- [x] Added a config field → classified in `src/reference/settings-schema.md`, read-time default in
  `src/core/repo-settings.md`, asked in `src/setup/bootstrap.md`
  <!-- no config field added -->
- [x] Changed the config shape an EXISTING repo already has (renamed, removed, restructured) →
  `llm-upgrades/vN.md` + its line in `llm-upgrades/index.md` + the checkpoint in
  `src/core/llm-upgrades-index.md`. A new field with a read-time default needs no migration
  <!-- config shape untouched; no schema_version bump -->
- [x] No new `allowed-tools` grant is broader than necessary (e.g. a blanket `gh api:*`) — the PR
  content being reviewed is untrusted data
  <!-- no command frontmatter touched -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
